### PR TITLE
Fix exact crew context navigation from Bridge notifications

### DIFF
--- a/src/probos/notification_context.py
+++ b/src/probos/notification_context.py
@@ -1,0 +1,130 @@
+"""Read-only resolution of durable notification provenance to current context."""
+
+from __future__ import annotations
+
+import logging
+import re
+from collections.abc import Awaitable, Callable
+from typing import Protocol
+
+from probos.crew_session_delivery import (
+    CrewSessionDeliveryOutboxEntry,
+    CrewSessionDeliveryRecord,
+)
+from probos.crew_session_live import LoadedCrewSessionProjection
+from probos.threads import ChatThread
+
+logger = logging.getLogger(__name__)
+
+
+class NotificationDeliveryReader(Protocol):
+    async def get_crew_session_delivery(
+        self, delivery_id: str,
+    ) -> CrewSessionDeliveryOutboxEntry | None: ...
+
+
+class NotificationThreadReader(Protocol):
+    def get_thread(self, thread_id: str) -> ChatThread | None: ...
+
+
+class NotificationContextError(Exception):
+    def __init__(self, status_code: int) -> None:
+        self.status_code = status_code
+        self.detail = {
+            404: "notification_context_not_found",
+            409: "notification_context_conflict",
+            410: "notification_context_archived",
+            422: "notification_context_id_invalid",
+            503: "notification_context_unavailable",
+        }[status_code]
+        super().__init__(self.detail)
+
+
+class NotificationContextResolver:
+    def __init__(
+        self,
+        *,
+        delivery_store: NotificationDeliveryReader | None,
+        thread_store: NotificationThreadReader | None,
+        load_projection: Callable[
+            [str], Awaitable[LoadedCrewSessionProjection | None]
+        ] | None,
+    ) -> None:
+        self._deliveries = delivery_store
+        self._threads = thread_store
+        self._load_projection = load_projection
+
+    def _current_thread(self, record: CrewSessionDeliveryRecord) -> ChatThread:
+        if self._threads is None:
+            raise NotificationContextError(503)
+        thread = self._threads.get_thread(record.thread_id)
+        if thread is None:
+            raise NotificationContextError(404)
+        if thread.id != record.thread_id or thread.task_id != record.session_id:
+            raise NotificationContextError(409)
+        if thread.archived:
+            raise NotificationContextError(410)
+        return thread
+
+    async def resolve(self, notification_id: str) -> dict[str, object]:
+        """Return only current correlated context; never replay delivery actions."""
+        if (
+            type(notification_id) is not str
+            or re.fullmatch(r"[0-9a-f]{64}", notification_id) is None
+        ):
+            raise NotificationContextError(422)
+        if (
+            self._deliveries is None
+            or self._threads is None
+            or self._load_projection is None
+        ):
+            raise NotificationContextError(503)
+        try:
+            entry = await self._deliveries.get_crew_session_delivery(notification_id)
+            if entry is None:
+                raise NotificationContextError(404)
+            if (
+                type(entry) is not CrewSessionDeliveryOutboxEntry
+                or type(entry.record) is not CrewSessionDeliveryRecord
+            ):
+                raise NotificationContextError(409)
+            record = CrewSessionDeliveryRecord.from_payload(entry.record.to_payload())
+            if record.delivery_id != notification_id:
+                raise NotificationContextError(409)
+            self._current_thread(record)
+            loaded = await self._load_projection(record.session_id)
+            thread = self._current_thread(record)
+            if loaded is None:
+                raise NotificationContextError(404)
+            detail = loaded.detail
+            if (
+                loaded.parent.id != record.session_id
+                or loaded.parent.work_type != "crew_session"
+                or detail.task_id != record.session_id
+                or detail.thread_id != record.thread_id
+                or detail.origin != record.origin
+                or detail.originator_id != record.originator_id
+                or detail.revision < record.session_revision
+                or (
+                    detail.revision == record.session_revision
+                    and detail.state != record.outcome
+                )
+            ):
+                raise NotificationContextError(409)
+            return {
+                "kind": "crew_session",
+                "notification_id": notification_id,
+                "delivery_revision": record.session_revision,
+                "thread": thread.to_dict(),
+                "session": detail.to_wire(),
+            }
+        except NotificationContextError:
+            raise
+        except (ValueError, TypeError) as exc:
+            raise NotificationContextError(409) from exc
+        except Exception as exc:
+            logger.warning(
+                "Notification context read failed; current destination cannot be "
+                "verified; returning unavailable without navigation",
+            )
+            raise NotificationContextError(503) from exc

--- a/src/probos/notifications.py
+++ b/src/probos/notifications.py
@@ -144,8 +144,8 @@ class NotificationQueue:
         if not n:
             return False
         n.acknowledged = True
-        self._emit(EventType.NOTIFICATION_ACK, n)
         self._prune_acknowledged()
+        self._emit(EventType.NOTIFICATION_ACK, n)
         return True
 
     def acknowledge_all(self) -> int:
@@ -154,9 +154,9 @@ class NotificationQueue:
             if not n.acknowledged:
                 n.acknowledged = True
                 count += 1
+        self._prune_acknowledged()
         if count > 0:
             self._emit_snapshot()
-        self._prune_acknowledged()
         return count
 
     @property

--- a/src/probos/routers/system.py
+++ b/src/probos/routers/system.py
@@ -14,9 +14,13 @@ from fastapi.responses import FileResponse, JSONResponse
 from pydantic import BaseModel, Field
 
 from probos.api_models import ShutdownRequest
+from probos.crew_session_live import LoadedCrewSessionProjection, load_crew_session_projection
+from probos.crew_session_projection import CrewSessionProjectionError
 from probos.events import OSActivityEvent
 from probos.mesh.intent import IntentAuthorizationDenied
+from probos.notification_context import NotificationContextError, NotificationContextResolver
 from probos.proactive import build_proactive_status_snapshot
+from probos.routers.auth import require_crew_scope
 from probos.routers.deps import get_runtime, get_task_tracker
 from probos.types import IntentMessage
 
@@ -409,6 +413,59 @@ async def update_communications_settings(body: dict, runtime: Any = Depends(get_
             raise HTTPException(status_code=400, detail=f"Invalid rank. Must be one of: {valid_ranks}")
         runtime.config.communications.recreation_min_rank = rank_val
     return await get_communications_settings(runtime=runtime)
+
+
+@router.get("/notifications/{notification_id}/context")
+async def notification_context(
+    notification_id: str,
+    request: Request,
+    runtime: Any = Depends(get_runtime),
+) -> JSONResponse:
+    """Resolve an exact durable delivery without acknowledging or executing it."""
+    headers = {"Cache-Control": "no-store"}
+    try:
+        await require_crew_scope(
+            request=request,
+            authorization=request.headers.get("authorization"),
+            runtime=runtime,
+        )
+    except HTTPException as exc:
+        exc.headers = {**(exc.headers or {}), **headers}
+        raise
+
+    work = getattr(runtime, "work_item_store", None)
+    service = getattr(runtime, "crew_session_service", None)
+
+    async def load_current(parent_id: str) -> LoadedCrewSessionProjection | None:
+        if await work.get_work_item(parent_id) is None:
+            return None
+        if await service.get_session(parent_id) is None:
+            return None
+        try:
+            return await load_crew_session_projection(
+                parent_id,
+                crew_session_service=service,
+                work_item_store=work,
+            )
+        except CrewSessionProjectionError:
+            if await work.get_work_item(parent_id) is None:
+                return None
+            if await service.get_session(parent_id) is None:
+                return None
+            raise
+
+    resolver = NotificationContextResolver(
+        delivery_store=work,
+        thread_store=getattr(runtime, "chat_thread_store", None),
+        load_projection=load_current if work is not None and service is not None else None,
+    )
+    try:
+        context = await resolver.resolve(notification_id)
+    except NotificationContextError as exc:
+        raise HTTPException(
+            status_code=exc.status_code, detail=exc.detail, headers=headers,
+        ) from exc
+    return JSONResponse(context, headers=headers)
 
 
 @router.post("/notifications/{notification_id}/ack")

--- a/src/probos/workforce.py
+++ b/src/probos/workforce.py
@@ -4364,6 +4364,28 @@ class WorkItemStore(EventEmitterMixin):
                 return False
         return True
 
+    async def get_crew_session_delivery(
+        self,
+        delivery_id: str,
+    ) -> CrewSessionDeliveryOutboxEntry | None:
+        """Read one validated delivery, including already delivered records."""
+        if (
+            type(delivery_id) is not str
+            or re.fullmatch(r"[0-9a-f]{64}", delivery_id) is None
+        ):
+            raise ValueError("crew_delivery_outbox_identity_invalid")
+        async with self._work_item_row_write_lock:
+            if self._db is None:
+                raise RuntimeError("crew_delivery_outbox_unavailable")
+            cursor = await self._db.execute(
+                "SELECT delivery_id, session_id, session_revision, outcome, "
+                "occurred_at, payload_json, delivered, created_at, delivered_at "
+                "FROM crew_delivery_outbox WHERE delivery_id = ?",
+                (delivery_id,),
+            )
+            row = await cursor.fetchone()
+        return None if row is None else _crew_delivery_entry_from_row(row)
+
     async def list_pending_crew_session_deliveries(
         self,
         *,

--- a/tests/test_ad1131_crew_session_delivery_metrics.py
+++ b/tests/test_ad1131_crew_session_delivery_metrics.py
@@ -51,6 +51,36 @@ _SHA_A = "a" * 64
 _CASE_IDS = itertools.count(1)
 
 
+@pytest.mark.parametrize("acknowledge_all", [False, True])
+def test_acknowledgement_emits_pruned_snapshot(acknowledge_all: bool) -> None:
+    events: list[tuple[str, dict[str, Any]]] = []
+    queue = NotificationQueue(on_event=lambda kind, data: events.append((kind, data)))
+    notifications = [
+        queue.notify("operations", "operations_officer", "operations", str(index))
+        for index in range(51)
+    ]
+    for index, notification in enumerate(notifications):
+        notification.created_at = float(index)
+    if acknowledge_all:
+        assert queue.acknowledge_all() == 51
+    else:
+        for notification in notifications:
+            assert queue.acknowledge(notification.id)
+    assert queue.count == 50
+    assert queue.unread_count() == 0
+    assert queue.get(notifications[0].id) is None
+    assert {item["id"] for item in queue.snapshot()} == {
+        notification.id for notification in notifications[1:]
+    }
+    assert events[-1][0] == (
+        EventType.NOTIFICATION_SNAPSHOT if acknowledge_all else EventType.NOTIFICATION_ACK
+    )
+    assert events[-1][1]["notifications"] == queue.snapshot()
+    assert events[-1][1]["unread_count"] == 0
+    assert queue.acknowledge_all() == 0
+    assert not queue.acknowledge("missing")
+
+
 class _ManualClock:
     def __init__(self, now: float = 100.0) -> None:
         self.now = now
@@ -360,7 +390,7 @@ class _OutcomeCase:
 
 
 @pytest.fixture
-async def harness(tmp_path: Path) -> Any:
+async def harness(tmp_path: Path, request: pytest.FixtureRequest) -> Any:
     work_path = str(tmp_path / "workforce.db")
     events = _RuntimeEnvelopeRecorder()
     connection_factory = _RecordingConnectionFactory()
@@ -378,7 +408,15 @@ async def harness(tmp_path: Path) -> Any:
             (event_type, copy.deepcopy(data)),
         ),
     )
-    threads = ChatThreadStore(tmp_path / "threads.db")
+    service_clock = _ManualClock()
+    if getattr(request, "param", None) == "notification-navigation":
+        thread_ids = itertools.count(1)
+        threads = ChatThreadStore(
+            tmp_path / "threads.db", clock=service_clock,
+            id_factory=lambda: f"notification-navigation-{next(thread_ids)}",
+        )
+    else:
+        threads = ChatThreadStore(tmp_path / "threads.db")
     admission = work.claim_crew_session_admission_port()
     registry = AgentRegistry()
     for agent_id in ("facilitator-metrics", "producer-metrics"):
@@ -395,7 +433,6 @@ async def harness(tmp_path: Path) -> Any:
         task.add_done_callback(scheduled_tasks.discard)
         return task
 
-    service_clock = _ManualClock()
     service = CrewSessionService(
         work_item_store=work,
         chat_thread_store=threads,
@@ -454,6 +491,7 @@ def _status_event(
 async def _new_session(
     value: _Harness,
     *,
+    case_id: str | None = None,
     origin: str = "captain",
     originator_id: str = "captain",
     facilitator_id: str | None = None,
@@ -462,7 +500,7 @@ async def _new_session(
     expected_deliverable: str = "A verified report",
     owner_ids: list[str] | None = None,
 ) -> tuple[CrewSessionService, CrewSessionContract, ChatThread]:
-    index = next(_CASE_IDS)
+    index = case_id if case_id is not None else next(_CASE_IDS)
     session_id = f"session-{index}"
     facilitator = facilitator_id or f"facilitator-{index}"
     created_by = "captain" if origin == "captain" else originator_id
@@ -502,6 +540,7 @@ async def _make_outcome(
     value: _Harness,
     outcome: str,
     *,
+    case_id: str | None = None,
     origin: str = "captain",
     originator_id: str = "captain",
     facilitator_id: str | None = None,
@@ -516,6 +555,7 @@ async def _make_outcome(
 ) -> _OutcomeCase:
     service, contract, thread = await _new_session(
         value,
+        case_id=case_id,
         origin=origin,
         originator_id=originator_id,
         facilitator_id=facilitator_id,
@@ -1472,6 +1512,204 @@ async def test_exact_delivery_reread_rejects_bool_alias_corruption(
 
     with pytest.raises(ValueError, match="crew_delivery_outbox_corrupt"):
         await _exact_delivery(harness.work, pending[0].record)
+
+
+@pytest.mark.parametrize("delivered", [False, True])
+async def test_get_crew_session_delivery_exact_read_survives_reopen(
+    harness: _Harness, delivered: bool,
+) -> None:
+    case = await _make_outcome(harness, "failed")
+    pending = await harness.work.list_pending_crew_session_deliveries(limit=2)
+    assert len(pending) == 1
+    record = pending[0].record
+    if delivered:
+        assert await harness.delivery.on_status_changed(case.event) == 1
+    before = await _exact_delivery(harness.work, record)
+    harness.connection.queries.clear()
+    assert await harness.work.get_crew_session_delivery(record.delivery_id) == before
+    assert len(harness.connection.queries) == 1
+    query, parameters = harness.connection.queries[0]
+    assert "WHERE delivery_id = ?" in query
+    assert parameters == (record.delivery_id,)
+    assert before.delivered is delivered
+    await harness.work.stop()
+    with pytest.raises(RuntimeError, match="crew_delivery_outbox_unavailable"):
+        await harness.work.get_crew_session_delivery(record.delivery_id)
+    await harness.work.start()
+    assert await harness.work.get_crew_session_delivery(record.delivery_id) == before
+
+
+class _DeliveryIdSubclass(str):
+    pass
+
+
+@pytest.mark.parametrize(
+    "delivery_id", ["", "a" * 63, "A" * 64, "g" * 64, None, 1, _DeliveryIdSubclass(_SHA_A)],
+)
+async def test_get_crew_session_delivery_invalid_identity_rejected(
+    harness: _Harness, delivery_id: Any,
+) -> None:
+    with pytest.raises(ValueError, match="crew_delivery_outbox_identity_invalid"):
+        await harness.work.get_crew_session_delivery(delivery_id)
+
+
+async def test_get_crew_session_delivery_absent_returns_none(harness: _Harness) -> None:
+    assert await harness.work.get_crew_session_delivery(_SHA_A) is None
+
+
+@pytest.mark.parametrize(
+    "corruption", ["payload", "column", "revision", "outcome", "occurred_at"],
+)
+async def test_get_crew_session_delivery_corruption_rejected(
+    harness: _Harness, corruption: str,
+) -> None:
+    await _make_outcome(harness, "failed")
+    pending = await harness.work.list_pending_crew_session_deliveries(limit=2)
+    assert len(pending) == 1
+    record = pending[0].record
+    if corruption == "payload":
+        await harness.connection.execute(
+            "UPDATE crew_delivery_outbox SET payload_json = ? WHERE delivery_id = ?",
+            ("{}", record.delivery_id),
+        )
+    elif corruption == "column":
+        await harness.connection.execute(
+            "UPDATE crew_delivery_outbox SET session_id = ? WHERE delivery_id = ?",
+            ("other-parent", record.delivery_id),
+        )
+    elif corruption == "revision":
+        await harness.connection.execute(
+            "UPDATE crew_delivery_outbox SET session_revision = ? WHERE delivery_id = ?",
+            (record.session_revision + 1, record.delivery_id),
+        )
+    elif corruption == "outcome":
+        await harness.connection.execute(
+            "UPDATE crew_delivery_outbox SET outcome = ? WHERE delivery_id = ?",
+            ("done", record.delivery_id),
+        )
+    else:
+        await harness.connection.execute(
+            "UPDATE crew_delivery_outbox SET occurred_at = ? WHERE delivery_id = ?",
+            (record.occurred_at + 1.0, record.delivery_id),
+        )
+    await harness.connection.commit()
+    with pytest.raises(ValueError, match="crew_delivery_outbox_corrupt"):
+        await harness.work.get_crew_session_delivery(record.delivery_id)
+
+
+@pytest.mark.parametrize("harness", ["notification-navigation"], indirect=True)
+async def test_notification_context_real_failure_delivery_route_is_read_only(
+    harness: _Harness,
+) -> None:
+    from fastapi import FastAPI
+    from httpx import ASGITransport, AsyncClient
+
+    from probos.routers import system, threads
+    from probos.routers.deps import get_runtime
+
+    case = await _make_outcome(
+        harness, "failed", case_id="notification-navigation",
+        facilitator_id="facilitator-metrics",
+        owner_ids=["facilitator-metrics", "producer-metrics"],
+        summary="The navigation report could not be verified.",
+    )
+    assert await harness.delivery.on_status_changed(case.event) == 1
+    assert len(harness.notification_events) == 1
+    assert harness.notification_events[0][0] == EventType.NOTIFICATION
+    notification = harness.queue.snapshot()[0]
+    assert notification["notification_type"] == "error"
+    delivery_id = notification["id"]
+    entry = await harness.work.get_crew_session_delivery(delivery_id)
+    parent = await harness.work.get_work_item(case.contract.task_id)
+    messages = harness.threads.list_messages(case.thread.id)
+    events = copy.deepcopy(harness.notification_events)
+    app = FastAPI()
+    app.include_router(system.router)
+    app.include_router(threads.router)
+    runtime = SimpleNamespace(
+        config=SystemConfig(), work_item_store=harness.work,
+        crew_session_service=harness.service, chat_thread_store=harness.threads,
+    )
+    app.dependency_overrides[get_runtime] = lambda: runtime
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test",
+    ) as client:
+        response = await client.get(f"/api/notifications/{delivery_id}/context")
+        rooms_response = await client.get("/api/threads")
+        summaries_response = await client.get("/api/threads/summaries")
+        messages_response = await client.get(f"/api/threads/{case.thread.id}/messages")
+    assert response.status_code == 200
+    assert response.headers["cache-control"] == "no-store"
+    body = response.json()
+    assert set(body) == {"kind", "notification_id", "delivery_revision", "thread", "session"}
+    assert body["notification_id"] == delivery_id
+    assert body["thread"] == harness.threads.get_thread(case.thread.id).to_dict()
+    assert body["session"]["task_id"] == case.contract.task_id
+    assert body["session"]["state"] == "failed"
+    assert body["session"]["revision"] == body["delivery_revision"]
+    assert await harness.work.get_crew_session_delivery(delivery_id) == entry
+    assert await harness.work.get_work_item(case.contract.task_id) == parent
+    assert harness.threads.list_messages(case.thread.id) == messages
+    assert harness.notification_events == events
+    assert harness.queue.snapshot() == [notification]
+    assert rooms_response.status_code == 200
+    assert summaries_response.status_code == 200
+    assert messages_response.status_code == 200
+    rooms = rooms_response.json()
+    summaries = summaries_response.json()
+    assert rooms == {"threads": [body["thread"]]}
+    assert summaries["summaries"][case.thread.id]["session"]["state"] == "failed"
+    assert summaries["summaries"][case.thread.id]["session"]["task_id"] == case.contract.task_id
+    assert messages_response.json()["messages"] == [message.to_dict() for message in messages]
+    produced = {
+        "event": {"type": events[0][0], "data": events[0][1]},
+        "context": body,
+        "rooms": rooms,
+        "summaries": summaries,
+        "messages": messages_response.json(),
+    }
+    assert entry is not None
+    assert harness.queue.acknowledge(delivery_id)
+    assert harness.queue.notify_once(entry.record).acknowledged
+    assert await harness.delivery.on_status_changed(case.event) == 0
+    for index in range(51):
+        retained = harness.queue.notify(
+            "operations", "operations_officer", "operations", f"History {index}",
+        )
+        retained.created_at = 200.0 + index
+    assert harness.queue.acknowledge_all() == 51
+    assert harness.queue.count == 50
+    assert harness.queue.get(delivery_id) is None
+    retained_events = copy.deepcopy(harness.notification_events)
+    retained_snapshot = harness.queue.snapshot()
+    assert retained_events[-1][1]["notifications"] == retained_snapshot
+    await harness.work.stop()
+    await harness.work.start()
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test",
+    ) as client:
+        reopened = await client.get(f"/api/notifications/{delivery_id}/context")
+        retained_rooms = await client.get("/api/threads")
+        retained_summaries = await client.get("/api/threads/summaries")
+    assert reopened.status_code == 200
+    assert reopened.json() == body
+    assert retained_rooms.json() == rooms
+    assert retained_summaries.json() == summaries
+    assert harness.queue.get(delivery_id) is None
+    assert harness.queue.snapshot() == retained_snapshot
+    assert harness.notification_events == retained_events
+    assert await harness.work.get_work_item(case.contract.task_id) == parent
+    assert await harness.work.get_crew_session_delivery(delivery_id) == entry
+    assert harness.threads.list_messages(case.thread.id) == messages
+    fixture_path = (
+        Path(__file__).resolve().parents[1]
+        / "ui/e2e/fixtures/notification-navigation.json"
+    )
+    assert fixture_path.is_file(), (
+        "Worker must bank the deterministic producer fixture, then rerun this test:\n"
+        + json.dumps(produced, indent=2, sort_keys=True, allow_nan=False)
+    )
+    assert json.loads(fixture_path.read_text(encoding="utf-8")) == produced
 
 
 async def test_sensitive_contract_content_never_reaches_delivery_surfaces(

--- a/tests/test_ad1132_crew_session_api.py
+++ b/tests/test_ad1132_crew_session_api.py
@@ -16,12 +16,18 @@ from probos.cognitive.crew_session import (
     CrewSynthesisMetadata,
 )
 from probos.config import SystemConfig
+from probos.crew_session_delivery import (
+    CrewSessionDeliveryOutboxEntry,
+    build_crew_session_delivery_record,
+)
+from probos.crew_session_live import load_crew_session_projection
 from probos.crew_session_projection import (
     CREW_SESSION_PROJECTION_ERROR,
     build_crew_session_detail,
     build_crew_session_summary,
 )
 from probos.routers import crew_tasks as crew_tasks_router
+from probos.notification_context import NotificationContextError, NotificationContextResolver
 from probos.routers import threads as threads_router
 from probos.routers.deps import get_runtime
 from probos.storage.sqlite_factory import SQLiteConnectionFactory
@@ -238,6 +244,205 @@ async def _crew_parent(
     )
     harness.service.sessions[parent.id] = contract
     return parent, contract
+
+
+@pytest.mark.parametrize(
+    ("change", "expected_status"),
+    [
+        ("unchanged", 200), ("completed", 200), ("blocked", 200),
+        ("newer", 200), ("older", 409), ("outcome", 409),
+        ("origin", 409), ("originator", 409), ("session_thread", 409),
+        ("thread_task", 409), ("archived", 410), ("deleted", 404),
+        ("archive_during_load", 410), ("delete_during_load", 404),
+        ("rebind_during_load", 409), ("missing_projection", 404),
+    ],
+)
+async def test_notification_context_current_correlation(
+    api_harness: _Harness, change: str, expected_status: int,
+) -> None:
+    thread = api_harness.threads.create_thread(
+        title="Current room", participants=["facilitator-1"], task_id="context-parent",
+    )
+    state = {"completed": "done", "blocked": "blocked_needs_captain"}.get(change, "failed")
+    parent, session = await _crew_parent(
+        api_harness, parent_id="context-parent", state=state, thread_id=thread.id,
+        metadata={"crew_synth": _synthesis().model_dump(mode="json")} if state == "done" else None,
+    )
+    record = build_crew_session_delivery_record(session)
+    assert record.outcome == state
+    assert record.session_revision == session.revision == 3
+
+    class _DeliveryReader:
+        async def get_crew_session_delivery(
+            self, delivery_id: str,
+        ) -> CrewSessionDeliveryOutboxEntry | None:
+            assert delivery_id == record.delivery_id
+            return CrewSessionDeliveryOutboxEntry(
+                record=record, delivered=True, created_at=140.0, delivered_at=141.0,
+            )
+
+    updates: dict[str, Any] = {
+        "newer": {"revision": 4}, "older": {"revision": 2},
+        "outcome": {"state": "discussing", "completed_at": None},
+        "origin": {"origin": "agent", "originator_id": "facilitator-1"},
+        "originator": {"originator_id": "other-agent"},
+        "session_thread": {"thread_id": "other-room"},
+    }.get(change, {})
+    api_harness.service.sessions[parent.id] = session.model_copy(update=updates)
+    if change == "thread_task":
+        api_harness.threads.update_thread(thread.id, task_id="other-parent")
+    elif change == "archived":
+        api_harness.threads.update_thread(thread.id, archived=True)
+    elif change == "deleted":
+        api_harness.threads.delete_thread(thread.id)
+
+    async def load_current(parent_id: str) -> Any:
+        if change == "missing_projection":
+            return None
+        loaded = await load_crew_session_projection(
+            parent_id, crew_session_service=api_harness.service,
+            work_item_store=api_harness.work,
+        )
+        if change == "archive_during_load":
+            api_harness.threads.update_thread(thread.id, archived=True)
+        elif change == "delete_during_load":
+            api_harness.threads.delete_thread(thread.id)
+        elif change == "rebind_during_load":
+            api_harness.threads.update_thread(thread.id, task_id="other-parent")
+        return loaded
+
+    resolver = NotificationContextResolver(
+        delivery_store=_DeliveryReader(), thread_store=api_harness.threads,
+        load_projection=load_current,
+    )
+    if expected_status != 200:
+        with pytest.raises(NotificationContextError) as caught:
+            await resolver.resolve(record.delivery_id)
+        assert caught.value.status_code == expected_status
+    else:
+        result = await resolver.resolve(record.delivery_id)
+        assert set(result) == {"kind", "notification_id", "delivery_revision", "thread", "session"}
+        assert result["thread"] == thread.to_dict()
+        assert set(result["session"]) == _DETAIL_KEYS
+        assert result["session"]["revision"] == (4 if change == "newer" else 3)
+        assert result["session"]["state"] == state
+        assert result["delivery_revision"] == 3
+        if state == "done":
+            assert result["session"]["result"] == {
+                "artifact_id": "artifact-final", "content_hash": _SHA_B,
+                "result_ref": _SHA_A, "evidence_refs": [_SHA_A],
+            }
+            assert result["session"]["verification"] == {
+                "verifier_agent_id": "verifier-1", "confidence": 0.93,
+                "critique": "All criteria are satisfied.", "accepted_count": 2,
+                "total_count": 2, "convergence_rounds": 2,
+            }
+    assert api_harness.service.open_calls == 0
+
+
+class _NotificationIdSubclass(str):
+    pass
+
+
+@pytest.mark.parametrize(
+    "notification_id", [None, 1, "", "A" * 64, "a" * 65, _NotificationIdSubclass(_SHA_A)],
+)
+async def test_notification_context_invalid_id_precedes_dependency_reads(
+    notification_id: Any,
+) -> None:
+    resolver = NotificationContextResolver(
+        delivery_store=None, thread_store=None, load_projection=None,
+    )
+    with pytest.raises(NotificationContextError) as caught:
+        await resolver.resolve(notification_id)
+    assert caught.value.status_code == 422
+
+
+@pytest.mark.parametrize(
+    ("failure", "expected_status"),
+    [
+        ("unknown", 404), ("invalid_entry", 409), ("invalid_record", 409),
+        ("entry_subclass", 409), ("record_subclass", 409),
+        ("wrong_identity", 409), ("corrupt", 409), ("storage", 503),
+        ("thread", 503), ("projection", 503),
+        ("missing_store", 503), ("missing_threads", 503), ("missing_loader", 503),
+    ],
+)
+async def test_notification_context_dependency_failures_are_closed(
+    failure: str, expected_status: int,
+) -> None:
+    session = _session(task_id="context-parent", thread_id="context-room", state="failed")
+    record = build_crew_session_delivery_record(session)
+    calls: list[str] = []
+
+    class _EntrySubclass(CrewSessionDeliveryOutboxEntry):
+        pass
+
+    class _RecordSubclass(type(record)):
+        pass
+
+    class _DeliveryReader:
+        async def get_crew_session_delivery(
+            self, delivery_id: str,
+        ) -> CrewSessionDeliveryOutboxEntry | None:
+            calls.append("delivery")
+            assert delivery_id == record.delivery_id
+            if failure == "unknown":
+                return None
+            if failure == "invalid_entry":
+                return SimpleNamespace(record=record)
+            if failure == "corrupt":
+                raise ValueError("crew_delivery_outbox_corrupt")
+            if failure == "storage":
+                raise OSError("storage unavailable")
+            candidate = record
+            if failure == "invalid_record":
+                candidate = SimpleNamespace(**record.to_payload())
+            elif failure == "record_subclass":
+                candidate = _RecordSubclass(**record.to_payload())
+            elif failure == "wrong_identity":
+                candidate = build_crew_session_delivery_record(
+                    session.model_copy(update={"revision": 4}),
+                )
+            entry_type = _EntrySubclass if failure == "entry_subclass" else CrewSessionDeliveryOutboxEntry
+            return entry_type(
+                record=candidate, delivered=True, created_at=140.0, delivered_at=141.0,
+            )
+
+    class _ThreadReader:
+        def get_thread(self, thread_id: str) -> Any:
+            from probos.threads import ChatThread
+
+            calls.append("thread")
+            assert thread_id == "context-room"
+            if failure == "thread":
+                raise OSError("threads unavailable")
+            return ChatThread(
+                id=thread_id, title="Current room", participants=["facilitator-1"],
+                task_id="context-parent", created_at=100.0, last_active_at=140.0,
+            )
+
+    async def load_current(parent_id: str) -> Any:
+        calls.append("projection")
+        assert parent_id == "context-parent"
+        raise OSError("projection unavailable")
+
+    resolver = NotificationContextResolver(
+        delivery_store=None if failure == "missing_store" else _DeliveryReader(),
+        thread_store=None if failure == "missing_threads" else _ThreadReader(),
+        load_projection=None if failure == "missing_loader" else load_current,
+    )
+    with pytest.raises(NotificationContextError) as caught:
+        await resolver.resolve(record.delivery_id)
+    assert caught.value.status_code == expected_status
+    if failure.startswith("missing_"):
+        assert calls == []
+    elif failure == "projection":
+        assert calls == ["delivery", "thread", "projection"]
+    elif failure == "thread":
+        assert calls == ["delivery", "thread"]
+    else:
+        assert calls == ["delivery"]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -23,6 +23,12 @@ from probos.cognitive.llm_client import MockLLMClient
 from probos.config import SystemConfig
 from probos.runtime import ProbOSRuntime
 
+from tests.test_ad1131_crew_session_delivery_metrics import (
+    _Harness as _NotificationHarness,
+    _make_outcome,
+    harness as notification_delivery_harness,
+)
+
 
 # ------------------------------------------------------------------
 # Fixtures
@@ -48,6 +54,189 @@ async def runtime_no_utility(tmp_path):
     await rt.start()
     yield rt
     await rt.stop()
+
+
+@pytest.fixture
+def notification_context_api():
+    from types import SimpleNamespace
+
+    from fastapi import FastAPI
+
+    from probos.routers import system
+    from probos.routers.deps import get_runtime
+
+    app = FastAPI()
+    app.include_router(system.router)
+    runtime = SimpleNamespace(config=SystemConfig())
+    app.dependency_overrides[get_runtime] = lambda: runtime
+    return app, runtime
+
+
+@pytest.mark.parametrize("notification_id", ["short", "A" * 64, "a" * 65])
+async def test_notification_context_input_validation(notification_context_api, notification_id):
+    from httpx import ASGITransport, AsyncClient
+
+    app, _runtime = notification_context_api
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get(f"/api/notifications/{notification_id}/context")
+    assert response.status_code == 422
+    assert response.json() == {"detail": "notification_context_id_invalid"}
+    assert response.headers["cache-control"] == "no-store"
+
+
+async def test_notification_context_unavailable_default_auth_off(notification_context_api):
+    from httpx import ASGITransport, AsyncClient
+
+    app, _runtime = notification_context_api
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get(f"/api/notifications/{'a' * 64}/context")
+    assert response.status_code == 503
+    assert response.json() == {"detail": "notification_context_unavailable"}
+    assert response.headers["cache-control"] == "no-store"
+
+
+@pytest.mark.parametrize("authorization", [None, "Bearer wrong", "Bearer correct"])
+async def test_notification_context_auth_before_lookup(notification_context_api, authorization):
+    from httpx import ASGITransport, AsyncClient
+
+    app, runtime = notification_context_api
+    runtime.config.auth.crew_scope_token = "correct"
+    headers = {} if authorization is None else {"Authorization": authorization}
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get(f"/api/notifications/{'a' * 64}/context", headers=headers)
+    assert response.status_code == (503 if authorization == "Bearer correct" else 401)
+    assert set(response.json()) == {"detail"}
+    assert response.headers["cache-control"] == "no-store"
+
+
+@pytest.fixture
+async def persisted_notification_context(
+    notification_context_api: Any,
+    notification_delivery_harness: _NotificationHarness,
+) -> Any:
+    app, runtime = notification_context_api
+    harness = notification_delivery_harness
+    case = await _make_outcome(harness, "failed")
+    assert await harness.delivery.on_status_changed(case.event) == 1
+    assert len(harness.queue.snapshot()) == 1
+    runtime.work_item_store = harness.work
+    runtime.crew_session_service = harness.service
+    runtime.chat_thread_store = harness.threads
+    runtime.notification_queue = harness.queue
+    return app, runtime, harness, case
+
+
+@pytest.mark.parametrize(
+    ("configured", "authorization", "expected_status"),
+    [(False, None, 200), (True, None, 401), (True, "Bearer wrong", 401),
+     (True, "Bearer correct", 200)],
+)
+async def test_notification_context_valid_persisted_context_and_auth(
+    persisted_notification_context: Any,
+    configured: bool,
+    authorization: str | None,
+    expected_status: int,
+) -> None:
+    import copy
+
+    from httpx import ASGITransport, AsyncClient
+
+    from probos.crew_session_live import load_crew_session_projection
+
+    app, runtime, harness, case = persisted_notification_context
+    assert not runtime.config.agentic_dispatch.orchestrator_enabled
+    if configured:
+        runtime.config.auth.crew_scope_token = "correct"
+    notification = harness.queue.snapshot()[0]
+    parent = await harness.work.get_work_item(case.contract.task_id)
+    loaded = await load_crew_session_projection(
+        case.contract.task_id, crew_session_service=harness.service,
+        work_item_store=harness.work,
+    )
+    assert loaded is not None
+    entry = await harness.work.get_crew_session_delivery(notification["id"])
+    messages = harness.threads.list_messages(case.thread.id)
+    events = copy.deepcopy(harness.notification_events)
+    harness.connection.queries.clear()
+    headers = {} if authorization is None else {"Authorization": authorization}
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get(
+            f"/api/notifications/{notification['id']}/context", headers=headers,
+        )
+    assert response.status_code == expected_status
+    assert response.headers["cache-control"] == "no-store"
+    if expected_status == 401:
+        assert set(response.json()) == {"detail"}
+        assert harness.connection.queries == []
+    else:
+        assert response.json() == {
+            "kind": "crew_session", "notification_id": notification["id"],
+            "delivery_revision": case.contract.revision,
+            "thread": harness.threads.get_thread(case.thread.id).to_dict(),
+            "session": loaded.detail.to_wire(),
+        }
+        assert harness.connection.queries
+        assert all(sql.lstrip().upper().startswith("SELECT")
+                   for sql, _parameters in harness.connection.queries)
+    assert await harness.work.get_work_item(case.contract.task_id) == parent
+    assert await harness.work.get_crew_session_delivery(notification["id"]) == entry
+    assert harness.threads.list_messages(case.thread.id) == messages
+    assert harness.notification_events == events
+    assert harness.queue.snapshot() == [notification]
+
+
+@pytest.mark.parametrize(
+    ("failure", "expected_status", "detail"),
+    [
+        ("unknown", 404, "not_found"), ("deleted", 404, "not_found"),
+        ("archived", 410, "archived"), ("mismatch", 409, "conflict"),
+        ("corrupt", 409, "conflict"), ("unavailable", 503, "unavailable"),
+        ("missing_service", 503, "unavailable"),
+    ],
+)
+async def test_notification_context_persisted_error_boundaries(
+    persisted_notification_context: Any,
+    failure: str,
+    expected_status: int,
+    detail: str,
+) -> None:
+    import copy
+
+    from httpx import ASGITransport, AsyncClient
+
+    app, runtime, harness, case = persisted_notification_context
+    notification_id = harness.queue.snapshot()[0]["id"]
+    if failure == "unknown":
+        assert notification_id != "a" * 64
+        notification_id = "a" * 64
+    elif failure == "deleted":
+        harness.threads.delete_thread(case.thread.id)
+    elif failure == "archived":
+        harness.threads.update_thread(case.thread.id, archived=True)
+    elif failure == "mismatch":
+        harness.threads.update_thread(case.thread.id, task_id="other-parent")
+    elif failure == "corrupt":
+        await harness.connection.execute(
+            "UPDATE crew_delivery_outbox SET payload_json = ? WHERE delivery_id = ?",
+            ("{}", notification_id),
+        )
+        await harness.connection.commit()
+    elif failure == "unavailable":
+        await harness.work.stop()
+    elif failure == "missing_service":
+        runtime.crew_session_service = None
+    events = copy.deepcopy(harness.notification_events)
+    snapshot = harness.queue.snapshot()
+    harness.connection.queries.clear()
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get(f"/api/notifications/{notification_id}/context")
+    assert response.status_code == expected_status
+    assert response.json() == {"detail": f"notification_context_{detail}"}
+    assert response.headers["cache-control"] == "no-store"
+    assert all(sql.lstrip().upper().startswith("SELECT")
+               for sql, _parameters in harness.connection.queries)
+    assert harness.notification_events == events
+    assert harness.queue.snapshot() == snapshot
 
 
 # ------------------------------------------------------------------

--- a/ui/e2e/crew-session-live-refresh.spec.ts
+++ b/ui/e2e/crew-session-live-refresh.spec.ts
@@ -1,8 +1,11 @@
-import { expect, test, type WebSocketRoute } from '@playwright/test';
+import { expect, test, type Locator, type WebSocketRoute } from '@playwright/test';
+
+import notificationFixture from './fixtures/notification-navigation.json' with { type: 'json' };
 
 import {
   CREW,
   EZRI,
+  mkAgent,
   mkMessage,
   mkThread,
   mockChatApi,
@@ -131,9 +134,9 @@ function frame(
   });
 }
 
-function snapshot(generation: string) {
+function snapshot(generation: string, agents = CREW, notifications: Record<string, unknown>[] = []) {
   return frame('state_snapshot', {
-    agents: CREW.map(agent => ({
+    agents: agents.map(agent => ({
       id: agent.id,
       agent_type: agent.agentType,
       callsign: agent.callsign,
@@ -150,7 +153,336 @@ function snapshot(generation: string) {
     system_mode: 'active',
     tc_n: 0,
     routing_entropy: 0,
+    notifications,
   }, generation, 0);
+}
+
+for (const viewport of [{ width: 1440, height: 1000 }, { width: 900, height: 1000 }]) {
+  for (const activation of ['pointer', 'Enter', 'Space'] as const) {
+    test(`checked failure notification navigation ${activation} at ${viewport.width}px`, async ({ page }, testInfo) => {
+      test.setTimeout(90000);
+      await page.setViewportSize(viewport);
+      const { context, event, rooms, summaries, messages } = notificationFixture;
+      const sourceRoom = mkThread('synthetic-draft-source', 'Unsent draft room', ['ezri', 'yeo']);
+      const agents = [...CREW, ...context.thread.participants.map(id => mkAgent(id, id, 'operations'))];
+      const sockets: WebSocketRoute[] = [];
+      const mutations: string[] = [];
+      const contextRequests: string[] = [];
+      let sequence = 0;
+      const acknowledged = { ...event.data.notification, acknowledged: true };
+      const syntheticHistory = Array.from({ length: 51 }, (_, index) => ({
+        ...event.data.notification, id: `synthetic-history-${index}`, title: `Synthetic history ${index}`,
+      }));
+      const retained = syntheticHistory.slice(-50).map(item => ({ ...item, acknowledged: true }));
+      await page.addInitScript(({ width, height }) => {
+        localStorage.setItem('hxi_profile_panel_size', JSON.stringify({ w: Math.min(1060, width - 80), h: height - 120 }));
+        localStorage.setItem('probos.workspaceFiles.collapsed', width < 1000 ? '1' : '0');
+      }, viewport);
+      page.on('request', request => {
+        const path = new URL(request.url()).pathname;
+        if (path.startsWith('/api/') && !['GET', 'HEAD'].includes(request.method())) {
+          mutations.push(`${request.method()} ${path}`);
+        }
+      });
+      await mockChatApi(page, {
+        threads: [...rooms.threads, sourceRoom],
+        messagesByThread: { [messages.thread_id]: messages.messages, [sourceRoom.id]: [] },
+        roomSummaries: summaries.summaries,
+        crewDetailsByParent: { [context.session.task_id]: context.session },
+      });
+      await page.route(`**/api/threads/${context.thread.id}`, route => route.fulfill({ json: context.thread }));
+      await page.route(`**/api/threads/${sourceRoom.id}`, route => route.fulfill({ json: sourceRoom }));
+      await page.route('**/api/chat/attachments/multipart', route => route.fulfill({ json: {
+        attachment_id: SHA_A, url: '/attachment', sha256: SHA_A, mime: 'text/plain', size_bytes: 5,
+      } }));
+      await page.route('**/api/notifications/**', async route => {
+        const request = route.request();
+        const path = new URL(request.url()).pathname;
+        if (request.method() === 'GET' && path === `/api/notifications/${context.notification_id}/context`) {
+          contextRequests.push(path);
+          return route.fulfill({ json: context, headers: { 'Cache-Control': 'no-store' } });
+        }
+        if (request.method() === 'POST' && path === `/api/notifications/${context.notification_id}/ack`) {
+          sockets[0].send(frame('notification_ack', { notifications: [acknowledged], unread_count: 0 }, GENERATION_A, ++sequence));
+          return route.fulfill({ json: { ok: true } });
+        }
+        if (request.method() === 'POST' && path === '/api/notifications/ack-all') {
+          sockets[0].send(frame('notification_ack', { notifications: retained, unread_count: 0 }, GENERATION_A, ++sequence));
+          return route.fulfill({ json: { ok: true } });
+        }
+        return route.abort();
+      });
+      await page.routeWebSocket('**/ws/events*', socket => { sockets.push(socket); });
+      await gotoApp(page);
+      await expect.poll(() => sockets.length).toBe(1);
+      sockets[0].send(snapshot(GENERATION_A, agents));
+      await expect.poll(() => page.evaluate(() => (window as unknown as {
+        __store: { getState: () => { liveGeneration: string | null } };
+      }).__store.getState().liveGeneration)).toBe(GENERATION_A);
+      await seedAgents(page, agents);
+
+      await openGroupChat(page, EZRI.id, sourceRoom);
+      const composer = page.getByPlaceholder('Message...', { exact: true });
+      await composer.fill('Unsent source-room text');
+      await composer.locator('..').locator('input[type="file"]').setInputFiles({
+        name: 'draft.txt', mimeType: 'text/plain', buffer: Buffer.from('draft'),
+      });
+      await expect(page.getByText('draft.txt', { exact: true })).toBeVisible();
+      await page.getByTitle('Close', { exact: true }).click();
+      await expect(composer).toHaveCount(0);
+
+      const failureFrame = frame(event.type, event.data, GENERATION_A, ++sequence);
+      sockets[0].send(failureFrame);
+      const bridge = page.getByRole('button', { name: /^BRIDGE(?: \(\d+\))?$/ });
+      await expect(bridge).toHaveText('BRIDGE (1)');
+      await expect(bridge).toBeVisible();
+      sockets[0].send(failureFrame);
+      sockets[0].send(frame(event.type, event.data, GENERATION_A, ++sequence));
+      await expect(bridge).toHaveText('BRIDGE (1)');
+      await page.screenshot({ path: testInfo.outputPath('unread-badge.png') });
+      await bridge.click();
+      const openContext = page.getByRole('button', { name: `Open room context: ${event.data.notification.title}`, exact: true });
+      await expect(openContext).toHaveCount(1);
+      await expect(openContext).toBeVisible();
+      const activate = async (button: Locator): Promise<void> => {
+        if (activation === 'pointer') await button.click();
+        else {
+          await button.focus();
+          await expect(button).toBeFocused();
+          await button.press(activation);
+        }
+      };
+      const closeBridge = async (): Promise<void> => {
+        const beforeMutations = [...mutations];
+        const beforeRequests = [...contextRequests];
+        const profileThread = await page.evaluate(() => (window as unknown as {
+          __store: { getState: () => { activeProfileThreadId: string | null } };
+        }).__store.getState().activeProfileThreadId);
+        await page.getByRole('button', { name: 'Close Bridge', exact: true }).click();
+        await expect.poll(() => page.evaluate(() => (window as unknown as {
+          __store: { getState: () => { bridgeOpen: boolean } };
+        }).__store.getState().bridgeOpen)).toBe(false);
+        await expect(bridge).toHaveCSS('opacity', '1');
+        expect(mutations).toEqual(beforeMutations);
+        expect(contextRequests).toEqual(beforeRequests);
+        expect(await page.evaluate(() => (window as unknown as {
+          __store: { getState: () => { activeProfileThreadId: string | null } };
+        }).__store.getState().activeProfileThreadId)).toBe(profileThread);
+      };
+      const expectProfileBounds = async (): Promise<void> => {
+        const geometry = await page.getByTitle('Close', { exact: true }).evaluate(button => {
+          let panel = button.parentElement;
+          while (panel && getComputedStyle(panel).position !== 'fixed') panel = panel.parentElement;
+          if (!panel) throw new Error('Profile close control has no fixed outer panel');
+          const closeBounds = button.getBoundingClientRect();
+          return {
+            panel: panel.getBoundingClientRect().toJSON(),
+            close: closeBounds.toJSON(),
+            unobstructed: [
+              [closeBounds.left + 1, closeBounds.top + 1],
+              [closeBounds.right - 1, closeBounds.top + 1],
+              [closeBounds.left + 1, closeBounds.bottom - 1],
+              [closeBounds.right - 1, closeBounds.bottom - 1],
+              [closeBounds.left + closeBounds.width / 2, closeBounds.top + closeBounds.height / 2],
+            ].every(([horizontal, vertical]) => button.contains(document.elementFromPoint(horizontal, vertical))),
+          };
+        });
+        expect(geometry.unobstructed, 'Profile close must remain reachable while Bridge is open').toBe(true);
+        for (const bounds of [geometry.panel, geometry.close]) {
+          expect(bounds.width).toBeGreaterThan(0);
+          expect(bounds.height).toBeGreaterThan(0);
+          expect(bounds.left).toBeGreaterThanOrEqual(0);
+          expect(bounds.top).toBeGreaterThanOrEqual(0);
+          expect(bounds.right).toBeLessThanOrEqual(viewport.width);
+          expect(bounds.bottom).toBeLessThanOrEqual(viewport.height);
+        }
+      };
+      await activate(openContext);
+      const band = page.getByTestId('crew-collaboration-panel');
+      await expect(band).toHaveAttribute('data-state', 'failed');
+      await expect(band).toBeFocused();
+      await expect(band.getByRole('heading', { name: context.session.goal, exact: true })).toBeVisible();
+      await expect(band.getByText(context.session.last_result_summary, { exact: true })).toBeVisible();
+      await expect(page.getByRole('status').filter({ hasText: 'Notification room context opened. Showing current session state.' })).toBeVisible();
+      const destination = await page.evaluate(() => {
+        const state = (window as unknown as { __store: { getState: () => {
+          activeProfileThreadId: string | null; activeProfileAgent: string | null;
+          threadIdByAgent: Map<string, string>;
+          crewSessionsByParent: Map<string, { task_id: string; thread_id: string; state: string }>;
+        } } }).__store.getState();
+        return {
+          thread: state.activeProfileThreadId, host: state.activeProfileAgent,
+          defaults: [...state.threadIdByAgent], sessions: [...state.crewSessionsByParent.values()],
+        };
+      });
+      expect(destination.thread).toBe(context.thread.id);
+      expect(context.thread.participants).toContain(destination.host);
+      expect(destination.defaults).toEqual([]);
+      expect(destination.sessions).toContainEqual(context.session);
+      expect(contextRequests).toHaveLength(1);
+      expect(mutations).toEqual(['POST /api/chat/attachments/multipart']);
+      await expect(composer).toHaveValue('');
+      await expect(page.getByText('draft.txt', { exact: true })).toHaveCount(0);
+      await expect(page.getByTestId('chat-transcript')).not.toContainText(context.session.last_result_summary);
+      await expectProfileBounds();
+      expect(await page.evaluate(() => (window as unknown as {
+        __store: { getState: () => { bridgeOpen: boolean } };
+      }).__store.getState().bridgeOpen)).toBe(true);
+      await composer.fill('Unsent destination-room text');
+      await page.screenshot({ path: testInfo.outputPath('bridge-and-failure-context.png') });
+      await page.getByTitle('Close', { exact: true }).click();
+      await expect(band).toHaveCount(0);
+      await expect(composer).toHaveCount(0);
+      expect(await page.evaluate(() => {
+        const state = (window as unknown as { __store: { getState: () => {
+          bridgeOpen: boolean; activeProfileThreadId: string | null;
+        } } }).__store.getState();
+        return { bridge: state.bridgeOpen, thread: state.activeProfileThreadId };
+      })).toEqual({ bridge: true, thread: null });
+      await expect(page.getByRole('button', { name: 'Close Bridge', exact: true })).toBeVisible();
+      expect(contextRequests).toHaveLength(1);
+      expect(mutations).toEqual(['POST /api/chat/attachments/multipart']);
+      await openGroupChat(page, EZRI.id, sourceRoom);
+      await expect(composer).toHaveValue('Unsent source-room text');
+      await expect(page.getByText('draft.txt', { exact: true })).toBeVisible();
+      await page.getByTitle('Close', { exact: true }).click();
+      await activate(openContext);
+      await expect(band).toBeFocused();
+      await expect(band).toHaveAttribute('data-state', 'failed');
+      await expect(composer).toHaveValue('Unsent destination-room text');
+      await expect(page.getByText('draft.txt', { exact: true })).toHaveCount(0);
+      expect(contextRequests).toHaveLength(2);
+      expect(mutations).toEqual(['POST /api/chat/attachments/multipart']);
+      const profileTop = await page.getByTitle('Close', { exact: true }).evaluate(button => {
+        let panel = button.parentElement;
+        while (panel && getComputedStyle(panel).position !== 'fixed') panel = panel.parentElement;
+        if (!panel) throw new Error('Profile close control has no fixed outer panel');
+        return panel.getBoundingClientRect().top;
+      });
+      const bridgeCloseBounds = await page.getByRole('button', { name: 'Close Bridge', exact: true }).boundingBox();
+      expect(bridgeCloseBounds).not.toBeNull();
+      expect(bridgeCloseBounds!.y + bridgeCloseBounds!.height).toBeLessThanOrEqual(profileTop);
+      await closeBridge();
+      await expectProfileBounds();
+      await expect.poll(() => page.getByTitle('Close', { exact: true }).evaluate(button => {
+        const bounds = button.getBoundingClientRect();
+        return [
+          [bounds.left + 1, bounds.top + 1],
+          [bounds.right - 1, bounds.top + 1],
+          [bounds.left + 1, bounds.bottom - 1],
+          [bounds.right - 1, bounds.bottom - 1],
+          [bounds.left + bounds.width / 2, bounds.top + bounds.height / 2],
+        ].every(([horizontal, vertical]) => button.contains(document.elementFromPoint(horizontal, vertical)));
+      })).toBe(true);
+
+      const fit = await band.evaluate(element => {
+        const bounds = element.getBoundingClientRect();
+        const grid = element.querySelector('.crew-session-grid')!;
+        const sections = [...grid.children].map(child => child.getBoundingClientRect());
+        return {
+          left: bounds.left, right: bounds.right, top: bounds.top, bottom: bounds.bottom,
+          fits: [...element.querySelectorAll<HTMLElement>('h3, .crew-session-section')]
+            .every(child => child.scrollWidth <= child.clientWidth + 1),
+          separate: sections[0].right <= sections[1].left + 1 || sections[0].bottom <= sections[1].top + 1,
+        };
+      });
+      expect(fit.left).toBeGreaterThanOrEqual(0);
+      expect(fit.right).toBeLessThanOrEqual(viewport.width);
+      expect(fit.top).toBeGreaterThanOrEqual(0);
+      expect(fit.bottom).toBeLessThanOrEqual(viewport.height);
+      expect(fit.fits).toBe(true);
+      expect(fit.separate).toBe(true);
+      const bandBox = await band.boundingBox();
+      const composerBox = await composer.boundingBox();
+      expect(bandBox).not.toBeNull();
+      expect(composerBox).not.toBeNull();
+      expect(bandBox!.y + bandBox!.height).toBeLessThanOrEqual(composerBox!.y + 1);
+      await page.screenshot({ path: testInfo.outputPath('failure-context.png') });
+
+      await composer.fill('Unsent destination-room text');
+      await page.getByTitle('Close', { exact: true }).click();
+      await expect(band).toHaveCount(0);
+      await expect(composer).toHaveCount(0);
+      await openGroupChat(page, EZRI.id, sourceRoom);
+      await expect(composer).toHaveValue('Unsent source-room text');
+      await expect(page.getByText('draft.txt', { exact: true })).toBeVisible();
+      await page.getByTitle('Close', { exact: true }).click();
+      await bridge.click();
+      await page.getByRole('button', { name: 'Mark read', exact: true }).click();
+      await expect(page.getByRole('button', { name: 'Mark read', exact: true })).toHaveCount(0);
+      await expect(bridge).toHaveText('BRIDGE');
+      await expect(openContext).toBeEnabled();
+      await activate(openContext);
+      await expect(band).toBeFocused();
+      await expect(band).toHaveAttribute('data-state', 'failed');
+      await expect(composer).toHaveValue('Unsent destination-room text');
+      expect(contextRequests).toHaveLength(3);
+      await closeBridge();
+      await page.getByTitle('Close', { exact: true }).click();
+
+      await test.step('synthetic acknowledgement history prunes the checked card, not its failed room', async () => {
+        sockets[0].send(frame('notification_snapshot', {
+          notifications: [acknowledged, ...syntheticHistory], unread_count: syntheticHistory.length,
+        }, GENERATION_A, ++sequence));
+        await expect(bridge).toHaveText('BRIDGE (51)');
+        await bridge.click();
+        await closeBridge();
+        await expect(bridge).toHaveText('BRIDGE (51)');
+        await bridge.click();
+        await activate(openContext);
+        await expect(band).toBeFocused();
+        await expect(composer).toHaveValue('Unsent destination-room text');
+        await expectProfileBounds();
+        expect(contextRequests).toHaveLength(4);
+        const markAllBounds = await page.getByRole('button', { name: 'Mark all read', exact: true }).boundingBox();
+        expect(markAllBounds).not.toBeNull();
+        expect(markAllBounds!.y + markAllBounds!.height).toBeLessThanOrEqual(profileTop);
+        await page.getByRole('button', { name: 'Mark all read', exact: true }).click();
+        await expect.poll(() => mutations.filter(path => path === 'POST /api/notifications/ack-all').length).toBe(1);
+        await expect(openContext).toHaveCount(0);
+        await expect(bridge).toHaveText('BRIDGE');
+        await expect(band).toHaveAttribute('data-state', 'failed');
+        await expect(composer).toHaveValue('Unsent destination-room text');
+        expect(await page.evaluate(() => (window as unknown as {
+          __store: { getState: () => { activeProfileThreadId: string | null } };
+        }).__store.getState().activeProfileThreadId)).toBe(context.thread.id);
+        await closeBridge();
+        await page.getByTitle('Close', { exact: true }).click();
+        await bridge.click();
+        sockets[0].send(failureFrame);
+        await expect(openContext).toHaveCount(0);
+        await sockets[0].close({ code: 1012, reason: 'notification reconnect test' });
+        await expect.poll(() => sockets.length, { timeout: 5000 }).toBe(2);
+        sockets[1].send(snapshot(GENERATION_B, agents, retained));
+        await expect.poll(() => page.evaluate(() => (window as unknown as {
+          __store: { getState: () => { liveGeneration: string | null } };
+        }).__store.getState().liveGeneration)).toBe(GENERATION_B);
+        sockets[1].send(frame(event.type, event.data, GENERATION_A, sequence + 1));
+        sockets[1].send(frame('notification_snapshot', { notifications: retained, unread_count: 0 }, GENERATION_B, 1));
+        await expect.poll(() => page.evaluate(() => (window as unknown as {
+          __store: { getState: () => { liveSequence: number } };
+        }).__store.getState().liveSequence)).toBe(1);
+        await expect(openContext).toHaveCount(0);
+        await expect(page.getByRole('button', { name: /^Open room context: Synthetic history / })).toHaveCount(50);
+        await closeBridge();
+        await page.getByTestId('crew-collab-pill').click();
+        const row = page.getByTestId(`chat-row-${context.thread.id}`);
+        await expect(row).toBeVisible();
+        await expect(row).toContainText(context.session.goal);
+        await expect(row).toContainText('failed');
+        await expect(row).toContainText(context.session.last_result_summary);
+        await page.screenshot({ path: testInfo.outputPath('pruned-failed-room.png') });
+        await row.click();
+        await expect(band).toHaveAttribute('data-state', 'failed');
+        await expect(band.getByRole('heading')).toHaveText(context.session.goal);
+      });
+      expect(mutations).toEqual([
+        'POST /api/chat/attachments/multipart',
+        `POST /api/notifications/${context.notification_id}/ack`,
+        'POST /api/notifications/ack-all',
+      ]);
+    });
+  }
 }
 
 test('live CrewSession room refreshes and repairs through the sole stream', async ({ page }) => {

--- a/ui/e2e/fixtures/notification-navigation.json
+++ b/ui/e2e/fixtures/notification-navigation.json
@@ -1,0 +1,119 @@
+{
+  "context": {
+    "delivery_revision": 2,
+    "kind": "crew_session",
+    "notification_id": "14874e3e7b2cd7655d7641211d634988ea5c27aca7fcfbe2209770aadc74e634",
+    "session": {
+      "blocker": null,
+      "duplicate_resume_count": 0,
+      "expected_deliverable": "A verified report",
+      "facilitator_id": "facilitator-metrics",
+      "goal": "Deliver the requested result",
+      "last_result_summary": "The navigation report could not be verified.",
+      "origin": "captain",
+      "originator_id": "captain",
+      "owner_ids": ["facilitator-metrics", "producer-metrics"],
+      "progress": {"active": 0, "active_child": null, "done": 0, "failed": 0, "total": 0},
+      "result": null,
+      "revision": 2,
+      "state": "failed",
+      "success_criteria": ["The result is verified"],
+      "task_id": "session-notification-navigation",
+      "thread_id": "notification-navigation-1",
+      "timestamps": {
+        "completed_at": 120.0,
+        "created_at": 100.0,
+        "first_result_at": 120.0,
+        "started_at": null,
+        "transitioned_at": 120.0,
+        "verified_at": null
+      },
+      "verification": null
+    },
+    "thread": {
+      "archived": false,
+      "created_at": 100.0,
+      "id": "notification-navigation-1",
+      "last_active_at": 100.0,
+      "metadata": {},
+      "model": null,
+      "participants": ["facilitator-metrics", "producer-metrics"],
+      "personality_override": null,
+      "pinned": false,
+      "preprompt": null,
+      "project_id": null,
+      "task_id": "session-notification-navigation",
+      "title": "Crew room notification-navigation",
+      "workspace_root": null
+    }
+  },
+  "event": {
+    "data": {
+      "notification": {
+        "acknowledged": false,
+        "action_url": "thread:notification-navigation-1",
+        "agent_id": "facilitator-metrics",
+        "agent_type": "crew_session",
+        "created_at": 120.0,
+        "department": "operations",
+        "detail": "Open the existing crew room for details.",
+        "id": "14874e3e7b2cd7655d7641211d634988ea5c27aca7fcfbe2209770aadc74e634",
+        "notification_type": "error",
+        "suggested_action": null,
+        "title": "Crew session failed"
+      },
+      "notifications": [{
+        "acknowledged": false,
+        "action_url": "thread:notification-navigation-1",
+        "agent_id": "facilitator-metrics",
+        "agent_type": "crew_session",
+        "created_at": 120.0,
+        "department": "operations",
+        "detail": "Open the existing crew room for details.",
+        "id": "14874e3e7b2cd7655d7641211d634988ea5c27aca7fcfbe2209770aadc74e634",
+        "notification_type": "error",
+        "suggested_action": null,
+        "title": "Crew session failed"
+      }],
+      "unread_count": 1
+    },
+    "type": "notification"
+  },
+  "messages": {"messages": [], "thread_id": "notification-navigation-1"},
+  "rooms": {"threads": [{
+    "archived": false,
+    "created_at": 100.0,
+    "id": "notification-navigation-1",
+    "last_active_at": 100.0,
+    "metadata": {},
+    "model": null,
+    "participants": ["facilitator-metrics", "producer-metrics"],
+    "personality_override": null,
+    "pinned": false,
+    "preprompt": null,
+    "project_id": null,
+    "task_id": "session-notification-navigation",
+    "title": "Crew room notification-navigation",
+    "workspace_root": null
+  }]},
+  "summaries": {"summaries": {"notification-navigation-1": {
+    "outputs": 0,
+    "session": {
+      "blocker": null,
+      "facilitator_id": "facilitator-metrics",
+      "goal": "Deliver the requested result",
+      "last_result_summary": "The navigation report could not be verified.",
+      "needs_attention": false,
+      "owner_ids": ["facilitator-metrics", "producer-metrics"],
+      "progress": {"active": 0, "done": 0, "failed": 0, "total": 0},
+      "result_artifact_id": null,
+      "state": "failed",
+      "task_id": "session-notification-navigation",
+      "thread_id": "notification-navigation-1",
+      "verified_at": null
+    },
+    "steps_done": 0,
+    "steps_total": 0,
+    "topic": "Deliver the requested result"
+  }}}
+}

--- a/ui/src/__tests__/AgentProfilePanel.threadKeyed.test.tsx
+++ b/ui/src/__tests__/AgentProfilePanel.threadKeyed.test.tsx
@@ -4,7 +4,8 @@
  *  survives an absent/stale activeProfileAgent. A 1:1 stays keyed by
  *  activeProfileAgent and is byte-identical. */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { render, screen, waitFor, cleanup } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor, cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 vi.mock('@react-three/fiber', () => ({
@@ -42,6 +43,8 @@ vi.mock('../components/profile/ProfileChatTab', () => ({
 }));
 
 import { AgentProfilePanel } from '../components/profile/AgentProfilePanel';
+import { IntentSurface } from '../components/IntentSurface';
+import { ApprovalsCenterPanel } from '../components/approvals/ApprovalsCenterPanel';
 import { useStore } from '../store/useStore';
 
 const HOST = 'agent-counselor';
@@ -84,13 +87,19 @@ beforeEach(() => {
   }
   global.fetch = vi.fn((url: any) => {
     const u = String(url);
+    if (u === '/api/wardroom/dms') {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve([]) }) as any;
+    }
     if (u === '/api/config/avatars-enabled') {
       return Promise.resolve({ ok: true, json: () => Promise.resolve({ enabled: false }) }) as any;
     }
     if (u.endsWith('/profile')) {
       return Promise.resolve({
         ok: true,
-        json: () => Promise.resolve({ id: HOST, isCrew: true, department: 'medical', displayName: 'Ezri' }),
+        json: () => Promise.resolve({
+          id: HOST, isCrew: true, department: 'medical', displayName: 'Ezri',
+          specialization: [], hebbianConnections: [],
+        }),
       }) as any;
     }
     return Promise.resolve({ ok: true, json: () => Promise.resolve({}) }) as any;
@@ -99,8 +108,319 @@ beforeEach(() => {
 
 afterEach(cleanup);
 
+describe('#1373 local profile viewport geometry', () => {
+  let originalState: ReturnType<typeof useStore.getState>;
+  let originalWidth: PropertyDescriptor | undefined;
+  let originalHeight: PropertyDescriptor | undefined;
+  let originalSize: string | null;
+
+  function setViewport(width: number, height: number): void {
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: width });
+    Object.defineProperty(window, 'innerHeight', { configurable: true, value: height });
+  }
+
+  function mountPanel(size: { w: number; h: number }, position = { x: 100, y: 100 }): HTMLElement {
+    localStorage.setItem('hxi_profile_panel_size', JSON.stringify(size));
+    useStore.setState({ profilePanelPos: position });
+    const { container } = render(<AgentProfilePanel />);
+    expect(screen.getByTestId('profile-chat-tab')).toBeVisible();
+    return container.firstElementChild as HTMLElement;
+  }
+
+  function expectGeometry(panel: HTMLElement, left: number, top: number, width: number, height: number): void {
+    const style = getComputedStyle(panel);
+    expect(style.boxSizing).toBe('border-box');
+    expect(Number.parseFloat(style.left)).toBe(left);
+    expect(Number.parseFloat(style.top)).toBe(top);
+    expect(Number.parseFloat(style.width)).toBe(width);
+    expect(Number.parseFloat(style.height)).toBe(height);
+    expect(left).toBeGreaterThanOrEqual(0);
+    expect(top).toBeGreaterThanOrEqual(0);
+    expect(left + width).toBeLessThanOrEqual(window.innerWidth);
+    expect(top + height).toBeLessThanOrEqual(window.innerHeight);
+  }
+
+  beforeEach(() => {
+    originalState = useStore.getState();
+    originalWidth = Object.getOwnPropertyDescriptor(window, 'innerWidth');
+    originalHeight = Object.getOwnPropertyDescriptor(window, 'innerHeight');
+    originalSize = localStorage.getItem('hxi_profile_panel_size');
+    setViewport(900, 1000);
+    useStore.setState({
+      activeProfileAgent: HOST, activeProfileThreadId: 'g1',
+      agents: _seedAgents(), chatThreads: _groupThread(),
+      profilePanelPos: { x: 100, y: 100 }, poolToGroup: { medical: 'medical' },
+      agentConversations: new Map(), liveGeneration: null,
+      notificationNavigation: {
+        requestId: Symbol('geometry'), generation: null,
+        destination: { hostId: HOST, threadId: 'g1', parentId: 'parent', updated: false },
+      },
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    useStore.setState(originalState, true);
+    if (originalWidth) Object.defineProperty(window, 'innerWidth', originalWidth);
+    if (originalHeight) Object.defineProperty(window, 'innerHeight', originalHeight);
+    if (originalSize === null) localStorage.removeItem('hxi_profile_panel_size');
+    else localStorage.setItem('hxi_profile_panel_size', originalSize);
+    vi.restoreAllMocks();
+  });
+
+  it('keeps a fitting preferred rectangle unchanged', () => {
+    const preferred = { w: 420, h: 580 };
+    const panel = mountPanel(preferred);
+    expectGeometry(panel, 100, 100, 420, 580);
+    expect(localStorage.getItem('hxi_profile_panel_size')).toBe(JSON.stringify(preferred));
+    expect(useStore.getState().profilePanelPos).toEqual({ x: 100, y: 100 });
+  });
+
+  it('keeps the actual profile above Bridge and below approvals without closing Bridge or mutating work', async () => {
+    const user = userEvent.setup();
+    const closeProfile = vi.fn(useStore.getState().closeAgentProfile);
+    useStore.setState({
+      bridgeOpen: false, approvalsCenterOpen: false, pendingApprovals: [],
+      agentTasks: [], notifications: [], missionControlTasks: [],
+      wardRoomDmChannels: [], wardRoomUnread: {}, closeAgentProfile: closeProfile,
+    });
+    render(<><IntentSurface /><AgentProfilePanel /><ApprovalsCenterPanel /></>);
+    const toggle = await screen.findByRole('button', { name: /^BRIDGE/ });
+    await user.click(toggle);
+    expect(useStore.getState().bridgeOpen).toBe(true);
+    expect(screen.getByTestId('profile-chat-tab')).toBeVisible();
+    const fixedRoot = (element: HTMLElement): HTMLElement => {
+      let current: HTMLElement | null = element;
+      while (current && getComputedStyle(current).position !== 'fixed') current = current.parentElement;
+      if (!current) throw new Error('Expected an actual fixed panel root');
+      return current;
+    };
+    const bridge = fixedRoot(screen.getByRole('button', { name: 'Close Bridge' }));
+    const profile = fixedRoot(screen.getByTitle('Close', { exact: true }));
+    expect(Number(getComputedStyle(profile).zIndex)).toBeGreaterThan(Number(getComputedStyle(bridge).zIndex));
+    expect(Number(getComputedStyle(bridge).zIndex)).toBeGreaterThan(Number(getComputedStyle(toggle).zIndex));
+    act(() => useStore.setState({ approvalsCenterOpen: true }));
+    const approvals = fixedRoot(await screen.findByRole('dialog'));
+    expect(Number(getComputedStyle(approvals).zIndex)).toBeGreaterThan(Number(getComputedStyle(profile).zIndex));
+    await user.keyboard('{Escape}');
+    expect(screen.queryByRole('dialog')).toBeNull();
+    const beforeClose = useStore.getState();
+    await user.click(screen.getByTitle('Close', { exact: true }));
+    expect(closeProfile).toHaveBeenCalledTimes(1);
+    expect(screen.queryByTestId('profile-chat-tab')).toBeNull();
+    expect(useStore.getState().activeProfileThreadId).toBeNull();
+    expect(useStore.getState().bridgeOpen).toBe(true);
+    expect(useStore.getState().notifications).toBe(beforeClose.notifications);
+    expect(useStore.getState().composerDrafts).toBe(beforeClose.composerDrafts);
+    expect((fetch as ReturnType<typeof vi.fn>).mock.calls.filter(([, options]) => options?.method === 'POST')).toEqual([]);
+  });
+
+  it('caps an oversized saved preference on the initial render without persisting the cap', () => {
+    const preferred = { w: 1600, h: 1200 };
+    const panel = mountPanel(preferred);
+    expectGeometry(panel, 0, 0, 900, 1000);
+    expect(localStorage.getItem('hxi_profile_panel_size')).toBe(JSON.stringify(preferred));
+    expect(useStore.getState().profilePanelPos).toEqual({ x: 100, y: 100 });
+  });
+
+  it.each([
+    { position: { x: -100, y: -100 }, left: 0, top: 0 },
+    { position: { x: 5000, y: 5000 }, left: 80, top: 240 },
+    { position: { x: Number.NaN, y: Number.POSITIVE_INFINITY }, left: 0, top: 0 },
+  ])('bounds the stored position $position without rewriting it', ({ position, left, top }) => {
+    const panel = mountPanel({ w: 820, h: 760 }, position);
+    expectGeometry(panel, left, top, 820, 760);
+    expect(useStore.getState().profilePanelPos).toEqual(position);
+  });
+
+  it.each([
+    null, '', 'null', '{}', 'not-json', '{"w":-1,"h":580}',
+    '{"w":420,"h":0}', '{"w":1e400,"h":580}', '{"w":420,"h":1e400}',
+    '{"w":"420","h":580}',
+  ])('uses finite default dimensions for an invalid or missing preference: %s', (stored) => {
+    if (stored === null) localStorage.removeItem('hxi_profile_panel_size');
+    else localStorage.setItem('hxi_profile_panel_size', stored);
+    const { container } = render(<AgentProfilePanel />);
+    expectGeometry(container.firstElementChild as HTMLElement, 100, 100, 420, 580);
+  });
+
+  it('restores preferred geometry after shrink and re-expansion without remounting or navigating', () => {
+    setViewport(1440, 1000);
+    const preferred = { w: 1060, h: 880 };
+    const panel = mountPanel(preferred);
+    const body = screen.getByTestId('profile-chat-tab');
+    const before = useStore.getState();
+    const requests = (fetch as ReturnType<typeof vi.fn>).mock.calls.length;
+    expectGeometry(panel, 100, 100, 1060, 880);
+
+    act(() => { setViewport(900, 700); window.dispatchEvent(new Event('resize')); });
+    expectGeometry(panel, 0, 0, 900, 700);
+    expect(localStorage.getItem('hxi_profile_panel_size')).toBe(JSON.stringify(preferred));
+    act(() => { setViewport(1440, 1000); window.dispatchEvent(new Event('resize')); });
+    expectGeometry(panel, 100, 100, 1060, 880);
+    expect(screen.getByTestId('profile-chat-tab')).toBe(body);
+    expect(useStore.getState().profilePanelPos).toBe(before.profilePanelPos);
+    expect(useStore.getState().notificationNavigation).toBe(before.notificationNavigation);
+    expect(useStore.getState().activeProfileThreadId).toBe('g1');
+    expect(useStore.getState().composerDrafts).toBe(before.composerDrafts);
+    expect((fetch as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(requests);
+  });
+
+  it('drags from effective coordinates and bounds both complete edges of a wide panel', () => {
+    const panel = mountPanel({ w: 820, h: 760 });
+    expectGeometry(panel, 80, 100, 820, 760);
+    fireEvent.mouseDown(screen.getByTestId('group-surface-title'), { clientX: 120, clientY: 120 });
+    fireEvent.mouseMove(window, { clientX: 120, clientY: 120 });
+    expectGeometry(panel, 80, 100, 820, 760);
+    fireEvent.mouseMove(window, { clientX: 5000, clientY: 5000 });
+    expectGeometry(panel, 80, 240, 820, 760);
+    expect(useStore.getState().profilePanelPos).toEqual({ x: 80, y: 240 });
+    fireEvent.mouseMove(window, { clientX: -100, clientY: -100 });
+    expectGeometry(panel, 0, 0, 820, 760);
+    fireEvent.mouseUp(window);
+    fireEvent.mouseMove(window, { clientX: 5000, clientY: 5000 });
+    expectGeometry(panel, 0, 0, 820, 760);
+  });
+
+  it('resizes from effective dimensions and retains minimum sizes when they fit', () => {
+    const panel = mountPanel({ w: 1600, h: 1200 });
+    fireEvent.mouseDown(screen.getByLabelText('Resize panel'), { clientX: 900, clientY: 1000 });
+    fireEvent.mouseMove(window, { clientX: 850, clientY: 950 });
+    expectGeometry(panel, 0, 0, 850, 950);
+    expect(localStorage.getItem('hxi_profile_panel_size')).toBe(JSON.stringify({ w: 850, h: 950 }));
+    fireEvent.mouseMove(window, { clientX: 5000, clientY: 5000 });
+    expectGeometry(panel, 0, 0, 900, 1000);
+    fireEvent.mouseMove(window, { clientX: -5000, clientY: -5000 });
+    expectGeometry(panel, 0, 0, 320, 360);
+    fireEvent.mouseUp(window);
+    fireEvent.mouseMove(window, { clientX: 5000, clientY: 5000 });
+    expectGeometry(panel, 0, 0, 320, 360);
+  });
+
+  it('limits resizing to the space remaining after the effective position', () => {
+    const panel = mountPanel({ w: 420, h: 580 });
+    fireEvent.mouseDown(screen.getByLabelText('Resize panel'), { clientX: 520, clientY: 680 });
+    fireEvent.mouseMove(window, { clientX: 5000, clientY: 5000 });
+    expectGeometry(panel, 100, 100, 800, 900);
+    expect(useStore.getState().profilePanelPos).toEqual({ x: 100, y: 100 });
+    fireEvent.mouseUp(window);
+  });
+
+  it('does not let resize minimums exceed a small viewport', () => {
+    setViewport(250, 300);
+    const panel = mountPanel({ w: 420, h: 580 });
+    expectGeometry(panel, 0, 0, 250, 300);
+    fireEvent.mouseDown(screen.getByLabelText('Resize panel'), { clientX: 250, clientY: 300 });
+    fireEvent.mouseMove(window, { clientX: -100, clientY: -100 });
+    expectGeometry(panel, 0, 0, 250, 300);
+    fireEvent.mouseUp(window);
+  });
+
+  it.each(['drag', 'resize'])('removes viewport and active %s listeners on unmount', (operation) => {
+    const addListener = vi.spyOn(window, 'addEventListener');
+    const removeListener = vi.spyOn(window, 'removeEventListener');
+    mountPanel({ w: 820, h: 760 });
+    fireEvent.mouseDown(operation === 'drag'
+      ? screen.getByTestId('group-surface-title') : screen.getByLabelText('Resize panel'),
+    { clientX: 200, clientY: 200 });
+    const listeners = addListener.mock.calls.filter(([type]) => ['resize', 'mousemove', 'mouseup'].includes(type));
+    expect(listeners.map(([type]) => type)).toEqual(expect.arrayContaining(['resize', 'mousemove', 'mouseup']));
+    cleanup();
+    for (const [type, handler] of listeners) {
+      expect(removeListener).toHaveBeenCalledWith(type, handler);
+    }
+  });
+});
 
 describe('AD-954a thread-keyed group surface', () => {
+  it('fits the complete notification-opened profile at 900px without rewriting its preference', () => {
+    const originalState = useStore.getState();
+    const originalWidth = Object.getOwnPropertyDescriptor(window, 'innerWidth');
+    const originalHeight = Object.getOwnPropertyDescriptor(window, 'innerHeight');
+    const originalSize = localStorage.getItem('hxi_profile_panel_size');
+    const preferredSize = JSON.stringify({ w: 820, h: 760 });
+    const navigation = {
+      requestId: Symbol('viewport-regression'), generation: null,
+      destination: { hostId: HOST, threadId: 'g1', parentId: 'parent', updated: false },
+    };
+    try {
+      Object.defineProperty(window, 'innerWidth', { configurable: true, value: 900 });
+      Object.defineProperty(window, 'innerHeight', { configurable: true, value: 1000 });
+      localStorage.setItem('hxi_profile_panel_size', preferredSize);
+      useStore.setState({
+        activeProfileAgent: HOST, activeProfileThreadId: 'g1',
+        agents: _seedAgents(), chatThreads: _groupThread(),
+        profilePanelPos: { x: 100, y: 100 }, poolToGroup: { medical: 'medical' },
+        agentConversations: new Map(), notificationNavigation: navigation, liveGeneration: null,
+      });
+      expect(useStore.getState().profilePanelPos.x + JSON.parse(preferredSize).w)
+        .toBeGreaterThan(window.innerWidth);
+      const { container } = render(<AgentProfilePanel />);
+      expect(screen.getByTestId('profile-chat-tab')).toBeVisible();
+      const panel = container.firstElementChild as HTMLElement;
+      const style = getComputedStyle(panel);
+      const left = Number.parseFloat(style.left);
+      const top = Number.parseFloat(style.top);
+      const outerWidth = Number.parseFloat(style.width) + (style.boxSizing === 'border-box' ? 0
+        : Number.parseFloat(style.borderLeftWidth) + Number.parseFloat(style.borderRightWidth));
+      const outerHeight = Number.parseFloat(style.height) + (style.boxSizing === 'border-box' ? 0
+        : Number.parseFloat(style.borderTopWidth) + Number.parseFloat(style.borderBottomWidth));
+      expect(left).toBeGreaterThanOrEqual(0);
+      expect(top).toBeGreaterThanOrEqual(0);
+      expect(outerWidth).toBeGreaterThan(0);
+      expect(outerHeight).toBeGreaterThan(0);
+      expect(left + outerWidth).toBeLessThanOrEqual(window.innerWidth);
+      expect(top + outerHeight).toBeLessThanOrEqual(window.innerHeight);
+      expect(localStorage.getItem('hxi_profile_panel_size')).toBe(preferredSize);
+      expect(useStore.getState().profilePanelPos).toEqual({ x: 100, y: 100 });
+      expect(useStore.getState().notificationNavigation).toBe(navigation);
+      expect(useStore.getState().activeProfileThreadId).toBe('g1');
+    } finally {
+      cleanup();
+      useStore.setState(originalState, true);
+      if (originalWidth) Object.defineProperty(window, 'innerWidth', originalWidth);
+      if (originalHeight) Object.defineProperty(window, 'innerHeight', originalHeight);
+      if (originalSize === null) localStorage.removeItem('hxi_profile_panel_size');
+      else localStorage.setItem('hxi_profile_panel_size', originalSize);
+    }
+  });
+
+  it('selects Chat only for the current notification destination and cancels on manual tab navigation', async () => {
+    const originalState = useStore.getState();
+    try {
+      useStore.setState({
+        activeProfileAgent: HOST, activeProfileThreadId: 'solo-room',
+        agents: _seedAgents(),
+        chatThreads: new Map([['solo-room', {
+          id: 'solo-room', title: 'Work room', participants: [HOST], task_id: 'parent',
+          created_at: 1, last_active_at: 1, metadata: {},
+        }]]),
+        profilePanelPos: { x: 0, y: 0 }, poolToGroup: { medical: 'medical' },
+        agentConversations: new Map(), notificationNavigation: null, liveGeneration: null,
+      });
+      render(<AgentProfilePanel />);
+      expect(await screen.findByTestId('profile-chat-tab')).toBeVisible();
+      fireEvent.click(screen.getByText('Profile'));
+      expect(screen.queryByTestId('profile-chat-tab')).toBeNull();
+      act(() => useStore.getState().setNotificationNavigation({
+        requestId: Symbol('stale'), generation: 'old-generation',
+        destination: { hostId: HOST, threadId: 'solo-room', parentId: 'parent', updated: false },
+      }));
+      expect(screen.queryByTestId('profile-chat-tab')).toBeNull();
+      act(() => useStore.getState().setNotificationNavigation({
+        requestId: Symbol('current'), generation: null,
+        destination: { hostId: HOST, threadId: 'solo-room', parentId: 'parent', updated: true },
+      }));
+      expect(await screen.findByTestId('profile-chat-tab')).toBeVisible();
+      fireEvent.click(screen.getByText('Profile'));
+      expect(useStore.getState().notificationNavigation).toBeNull();
+      expect(screen.queryByTestId('profile-chat-tab')).toBeNull();
+    } finally {
+      cleanup();
+      useStore.setState(originalState, true);
+    }
+  });
+
   it('mounts the group surface from the THREAD with no activeProfileAgent', async () => {
     // The decoupling forcing function: activeProfileAgent is null but the active
     // thread is a group. Pre-edit, agentId = activeProfileAgent = null → the

--- a/ui/src/__tests__/useStore.test.ts
+++ b/ui/src/__tests__/useStore.test.ts
@@ -1,6 +1,10 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { act, cleanup, renderHook } from '@testing-library/react';
 import { useStore, computeLayout } from '../store/useStore';
-import type { Agent, WSEvent } from '../store/types';
+import type { Agent, NotificationView, WSEvent } from '../store/types';
+import notificationFixture from '../../e2e/fixtures/notification-navigation.json';
+
+afterEach(cleanup);
 
 const GENERATION = 'a'.repeat(32);
 let nextLiveSequence = 0;
@@ -55,12 +59,135 @@ beforeEach(() => {
     liveCrewOwnerParentId: null,
     liveRailOwner: null,
     notifications: null,
+    notificationNavigation: null,
+    composerDrafts: new Map(),
+    chatDrafts: {},
   });
   // Clear localStorage
   localStorage.clear();
 });
 
 describe('useStore', () => {
+  describe('mounted notification stream retention', () => {
+    it('replaces acknowledged history without resurrecting it from duplicate or retired frames', () => {
+      const notification = notificationFixture.event.data.notification as NotificationView;
+      const { result } = renderHook(() => useStore(state => state.notifications));
+      act(() => {
+        installSnapshot();
+        useStore.getState().handleEvent(frame(notificationFixture.event.type, notificationFixture.event.data));
+      });
+      expect(result.current).toEqual([notification]);
+      expect(result.current?.filter(item => !item.acknowledged)).toHaveLength(1);
+
+      const duplicate = frame(notificationFixture.event.type, notificationFixture.event.data);
+      act(() => {
+        useStore.getState().handleEvent(duplicate);
+        useStore.getState().handleEvent(duplicate);
+      });
+      expect(result.current).toEqual([notification]);
+
+      const acknowledged = { ...notification, acknowledged: true };
+      act(() => useStore.getState().handleEvent(frame('notification_ack', {
+        notifications: [acknowledged], unread_count: 0,
+      })));
+      expect(result.current).toEqual([acknowledged]);
+      act(() => useStore.getState().handleEvent(duplicate));
+      expect(result.current).toEqual([acknowledged]);
+
+      const syntheticHistory = Array.from({ length: 51 }, (_, index) => ({
+        ...acknowledged, id: `synthetic-history-${index}`, title: `History ${index}`,
+      }));
+      act(() => useStore.getState().handleEvent(frame('notification_snapshot', {
+        notifications: [acknowledged, ...syntheticHistory], unread_count: 0,
+      })));
+      expect(result.current).toHaveLength(52);
+      const retained = syntheticHistory.slice(-50);
+      act(() => useStore.getState().handleEvent(frame('notification_ack', {
+        notifications: retained, unread_count: 0,
+      })));
+      expect(result.current).toEqual(retained);
+      expect(result.current?.some(item => item.id === notification.id)).toBe(false);
+
+      const retiredFrame = frame(notificationFixture.event.type, notificationFixture.event.data);
+      act(() => useStore.getState().handleEvent({
+        type: 'state_snapshot',
+        data: {
+          agents: [], connections: [], pools: [], system_mode: 'active',
+          tc_n: 0, routing_entropy: 0, notifications: retained,
+        },
+        timestamp: 200,
+        stream: { generation: 'b'.repeat(32), sequence: 0 },
+      }));
+      expect(useStore.getState().liveGeneration).toBe('b'.repeat(32));
+      expect(result.current).toEqual(retained);
+      act(() => useStore.getState().handleEvent(retiredFrame));
+      expect(result.current).toEqual(retained);
+      act(() => useStore.getState().handleEvent({
+        type: 'notification_snapshot', data: { notifications: [], unread_count: 0 },
+        timestamp: 201, stream: { generation: 'b'.repeat(32), sequence: 1 },
+      }));
+      expect(result.current).toBeNull();
+    });
+
+    it('hydrates initial unread notifications through the mounted snapshot selector', () => {
+      const { result } = renderHook(() => useStore(state => state.notifications));
+      act(() => useStore.getState().handleEvent(frame('state_snapshot', {
+        agents: [], connections: [], pools: [], system_mode: 'active',
+        tc_n: 0, routing_entropy: 0,
+        notifications: notificationFixture.event.data.notifications,
+      })));
+      expect(result.current).toEqual(notificationFixture.event.data.notifications);
+      expect(result.current?.filter(item => !item.acknowledged)).toHaveLength(1);
+    });
+  });
+
+  describe('notification navigation and composer ownership', () => {
+    it('keeps agent fallback and room drafts separate without persistence', () => {
+      const state = useStore.getState();
+      const beforeStorage = { ...localStorage };
+      state.updateComposerDraft('agent:host', draft => ({ ...draft, text: 'Before a room exists' }));
+      state.updateComposerDraft('thread:one', draft => ({ ...draft, text: 'First room' }));
+      state.updateComposerDraft('thread:two', draft => ({ ...draft, text: 'Second room' }));
+      state.openGroupChatThread('host', 'two');
+      expect(useStore.getState().composerDrafts.get('thread:one')?.text).toBe('First room');
+      expect(useStore.getState().composerDrafts.get('thread:two')?.text).toBe('Second room');
+      expect(useStore.getState().composerDrafts.get('agent:host')?.text).toBe('Before a room exists');
+      expect({ ...localStorage }).toEqual(beforeStorage);
+    });
+
+    it('keeps empty drafts and ignores an empty owner', () => {
+      const state = useStore.getState();
+      state.updateComposerDraft('', draft => ({ ...draft, text: 'Invalid owner' }));
+      expect(useStore.getState().composerDrafts.size).toBe(0);
+      state.updateComposerDraft('thread:one', draft => draft);
+      expect(useStore.getState().composerDrafts.get('thread:one')).toEqual({
+        text: '', attachments: [], pendingUploads: 0, error: null,
+      });
+    });
+
+    it('consumes the insertion inbox independently of saved room state', () => {
+      const state = useStore.getState();
+      state.updateComposerDraft('thread:one', draft => ({ ...draft, text: 'Saved room text' }));
+      state.setChatDraft('host', 'Insert this');
+      expect(state.consumeChatDraft('host')).toBe('Insert this');
+      expect(state.consumeChatDraft('host')).toBe('');
+      expect(useStore.getState().composerDrafts.get('thread:one')?.text).toBe('Saved room text');
+    });
+
+    it.each(['open', 'group', 'close', 'minimize'] as const)('invalidates a notification marker on %s', (navigation) => {
+      const state = useStore.getState();
+      state.openAgentProfile('host');
+      const marker = { requestId: Symbol('test'), generation: null, destination: null };
+      state.setNotificationNavigation(marker);
+      expect(useStore.getState().notificationNavigation).toBe(marker);
+      if (navigation === 'open') state.openAgentProfile('host');
+      if (navigation === 'group') state.openGroupChatThread('host', 'room');
+      if (navigation === 'close') state.closeAgentProfile();
+      if (navigation === 'minimize') state.minimizeAgentProfile();
+      expect(useStore.getState().notificationNavigation).toBeNull();
+    });
+  });
+
   describe('addChatMessage', () => {
     it('adds a user message to chat history', () => {
       useStore.getState().addChatMessage('user', 'Hello');

--- a/ui/src/components/BridgePanel.tsx
+++ b/ui/src/components/BridgePanel.tsx
@@ -366,7 +366,7 @@ export function BridgePanel({ open, onClose }: { open: boolean; onClose: () => v
       backdropFilter: 'blur(16px)',
       WebkitBackdropFilter: 'blur(16px)',
       borderLeft: '1px solid rgba(240, 176, 96, 0.15)',
-      zIndex: 20,
+      zIndex: 26,
       transform: open ? 'translateX(0)' : 'translateX(100%)',
       transition: 'transform 0.25s ease-out',
       display: 'flex',
@@ -406,6 +406,9 @@ export function BridgePanel({ open, onClose }: { open: boolean; onClose: () => v
             </button>
           )}
           <button
+            type="button"
+            aria-label="Close Bridge"
+            data-hxi-focus=""
             onClick={onClose}
             style={{
               background: 'none', border: 'none', color: '#888',

--- a/ui/src/components/approvals/__tests__/ApprovalsKeyboard.bf724.test.tsx
+++ b/ui/src/components/approvals/__tests__/ApprovalsKeyboard.bf724.test.tsx
@@ -142,6 +142,80 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
+describe('#1373 Bridge pointer controls', () => {
+  it('stacks the open panel above its actual invisible toggle and closes without mutation', async () => {
+    const user = userEvent.setup();
+    const originalState = useStore.getState();
+    try {
+      mountApprovalsRoute();
+      const toggle = await screen.findByRole('button', { name: /^BRIDGE/ });
+      await user.click(toggle);
+      expect(useStore.getState().bridgeOpen).toBe(true);
+      expect(getComputedStyle(toggle).opacity).toBe('0');
+      const header = screen.getByText('Bridge', { selector: 'span' });
+      const panel = header.parentElement!.parentElement!;
+      expect(getComputedStyle(panel).pointerEvents).toBe('auto');
+      expect(Number(getComputedStyle(panel).zIndex))
+        .toBeGreaterThan(Number(getComputedStyle(toggle).zIndex));
+      const close = within(panel).getByRole('button', { name: 'Close Bridge' });
+      expect(close).toHaveAttribute('type', 'button');
+      expect(close).toHaveAttribute('data-hxi-focus');
+      const beforeClose = useStore.getState();
+      await user.click(close);
+      expect(useStore.getState().bridgeOpen).toBe(false);
+      expect(getComputedStyle(panel).pointerEvents).toBe('none');
+      expect(useStore.getState().activeProfileThreadId).toBe(beforeClose.activeProfileThreadId);
+      expect(useStore.getState().notificationNavigation).toBe(beforeClose.notificationNavigation);
+      expect((fetch as unknown as ReturnType<typeof vi.fn>).mock.calls.filter(
+        ([, options]) => options?.method === 'POST',
+      )).toEqual([]);
+      await user.click(toggle);
+      expect(useStore.getState().bridgeOpen).toBe(true);
+    } finally {
+      cleanup();
+      useStore.setState(originalState, true);
+    }
+  });
+
+  it('names the actual close control and calls only onClose', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    render(<BridgePanel open={true} onClose={onClose} />);
+    await user.click(screen.getByRole('button', { name: 'Close Bridge' }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect((fetch as unknown as ReturnType<typeof vi.fn>).mock.calls.filter(
+      ([, options]) => options?.method === 'POST',
+    )).toEqual([]);
+  });
+
+  it('posts only ack-all for unread notifications and hides the action when none are unread', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    const originalState = useStore.getState();
+    try {
+      useStore.setState({ notifications: [{
+        id: 'layout-notification', agent_id: 'engineering-3', agent_type: 'builder', department: 'engineering',
+        notification_type: 'info', title: 'Layout notification', detail: '',
+        action_url: '', created_at: NOW_S, acknowledged: false,
+      }] });
+      const mounted = render(<BridgePanel open={true} onClose={onClose} />);
+      await user.click(screen.getByRole('button', { name: 'Mark all read' }));
+      expect((fetch as unknown as ReturnType<typeof vi.fn>).mock.calls.filter(
+        ([, options]) => options?.method === 'POST',
+      )).toEqual([['/api/notifications/ack-all', { method: 'POST' }]]);
+      expect(onClose).not.toHaveBeenCalled();
+      expect(useStore.getState().notifications?.[0].acknowledged).toBe(false);
+      mounted.unmount();
+      useStore.setState({ notifications: [] });
+      render(<BridgePanel open={true} onClose={onClose} />);
+      expect(screen.queryByRole('button', { name: 'Mark all read' })).toBeNull();
+    } finally {
+      cleanup();
+      useStore.setState(originalState, true);
+    }
+  });
+});
+
 describe('BF-724 the approvals route is operable from the keyboard', () => {
   it('tabs from BRIDGE to a pending approval, opens the centre and approves — no pointer at all', async () => {
     const user = userEvent.setup();

--- a/ui/src/components/bridge/BridgeNotifications.tsx
+++ b/ui/src/components/bridge/BridgeNotifications.tsx
@@ -1,8 +1,11 @@
 /* Bridge Notifications — notification card extracted from NotificationDropdown (AD-325) */
 
-import type { MouseEvent } from 'react';
+import { useEffect, useRef, useState, type MouseEvent } from 'react';
 
 import type { NotificationView } from '../../store/types';
+import { useStore } from '../../store/useStore';
+import { fetchNotificationContext } from '../sidebar/threadApi';
+import { hostAgentId } from '../chats/chatFilters';
 import { DEPT_COLORS } from './BridgeCards';
 
 export const TYPE_COLORS: Record<string, string> = {
@@ -25,6 +28,111 @@ export function NotificationCard({ notification }: { notification: NotificationV
   const borderColor = TYPE_COLORS[notification.notification_type] || '#5090d0';
   const isUnread = !notification.acknowledged;
   const acceptLabel = notification.suggested_action?.label;
+  const [loading, setLoading] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+  const pending = useRef<{ cancel: () => void } | null>(null);
+  const cardRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => () => { pending.current?.cancel(); }, [notification.id]);
+
+  async function handleOpen(): Promise<void> {
+    pending.current?.cancel();
+    const sourceCard = cardRef.current;
+    const sourceVisible = (): boolean => {
+      if (!sourceCard?.isConnected) return false;
+      for (let element: HTMLElement | null = sourceCard; element; element = element.parentElement) {
+        const style = getComputedStyle(element);
+        if (element.hidden || element.inert || element.getAttribute('aria-hidden') === 'true'
+          || style.display === 'none' || style.visibility === 'hidden' || style.pointerEvents === 'none') return false;
+      }
+      return true;
+    };
+    if (!sourceVisible()) return;
+    const source = useStore.getState();
+    const requestId = Symbol('notification-context');
+    const generation = source.liveGeneration;
+    const controller = new AbortController();
+    let cancelled = false;
+    let unsubscribe = () => {};
+    let visibilityObserver: MutationObserver | null = null;
+    const cancel = (): void => {
+      if (cancelled) return;
+      cancelled = true;
+      unsubscribe();
+      visibilityObserver?.disconnect();
+      controller.abort();
+      const current = useStore.getState();
+      if (current.notificationNavigation?.requestId === requestId
+        && !current.notificationNavigation.destination) {
+        current.setNotificationNavigation(null);
+      }
+    };
+    pending.current = { cancel };
+    source.setNotificationNavigation({ requestId, generation, destination: null });
+    setLoading(true);
+    setMessage(null);
+    const cancelFromSource = (): void => {
+      cancel();
+      setLoading(false);
+      setMessage('Context opening cancelled. Retry to open it from this view.');
+    };
+    visibilityObserver = new MutationObserver(() => {
+      if (!sourceVisible()) cancelFromSource();
+    });
+    for (let element: HTMLElement | null = sourceCard; element; element = element.parentElement) {
+      visibilityObserver.observe(element, {
+        attributes: true, attributeFilter: ['style', 'class', 'hidden', 'inert', 'aria-hidden'],
+      });
+    }
+    unsubscribe = useStore.subscribe((current) => {
+      if (current.notificationNavigation?.requestId !== requestId
+        || current.liveGeneration !== generation
+        || current.activeProfileAgent !== source.activeProfileAgent
+        || current.activeProfileThreadId !== source.activeProfileThreadId
+        || current.activeThreadId !== source.activeThreadId) {
+        cancelFromSource();
+      }
+    });
+    const outcome = await fetchNotificationContext(notification.id, controller.signal);
+    if (cancelled) return;
+    if (!sourceVisible()) {
+      cancelFromSource();
+      return;
+    }
+    unsubscribe();
+    visibilityObserver.disconnect();
+    pending.current = null;
+    setLoading(false);
+    if (outcome.kind !== 'success') {
+      cancel();
+      setMessage(outcome.status === 401
+        ? 'Context unavailable: authentication required.'
+        : outcome.status === 410
+          ? 'Context unavailable: this room is archived.'
+          : 'Context unavailable. Retry to check again.');
+      return;
+    }
+    const { thread, session, delivery_revision: deliveryRevision } = outcome.context;
+    const current = useStore.getState();
+    const hostId = hostAgentId(thread, current.agents);
+    const existingSession = current.crewSessionsByParent.get(session.task_id);
+    if (!hostId || (existingSession && existingSession.thread_id !== thread.id)) {
+      cancel();
+      setMessage('Context unavailable: this room has no usable current host or matching session.');
+      return;
+    }
+    current.setChatThread(thread);
+    current.hydrateCrewSession(session.task_id, session);
+    current.openGroupChatThread(hostId, thread.id);
+    current.setNotificationNavigation({
+      requestId, generation,
+      destination: {
+        hostId, threadId: thread.id, parentId: session.task_id,
+        updated: Math.max(session.revision, existingSession?.revision ?? 0) > deliveryRevision,
+      },
+    });
+    setMessage('Room context opened.');
+  }
 
   async function handleAck() {
     try {
@@ -33,7 +141,6 @@ export function NotificationCard({ notification }: { notification: NotificationV
   }
 
   async function handleAccept(e: MouseEvent) {
-    // Do not also trigger the card's onClick={handleAck}.
     e.stopPropagation();
     try {
       await fetch(`/api/notifications/${notification.id}/accept`, { method: 'POST' });
@@ -42,19 +149,26 @@ export function NotificationCard({ notification }: { notification: NotificationV
 
   return (
     <div
-      onClick={handleAck}
+      ref={cardRef}
       style={{
         marginBottom: 6,
         padding: '6px 8px 6px 12px',
         borderRadius: 6,
         background: isUnread ? 'rgba(255,255,255,0.06)' : 'rgba(255,255,255,0.02)',
         borderLeft: `3px solid ${borderColor}`,
-        cursor: 'pointer',
         transition: 'background 0.15s',
       }}
       onMouseEnter={e => { (e.currentTarget as HTMLDivElement).style.background = 'rgba(255,255,255,0.08)'; }}
       onMouseLeave={e => { (e.currentTarget as HTMLDivElement).style.background = isUnread ? 'rgba(255,255,255,0.06)' : 'rgba(255,255,255,0.02)'; }}
     >
+      <button
+        type="button"
+        onClick={handleOpen}
+        disabled={loading}
+        aria-label={`Open room context: ${notification.title}`}
+        aria-busy={loading}
+        style={{ display: 'block', width: '100%', border: 0, padding: 0, background: 'transparent', textAlign: 'left', font: 'inherit', cursor: loading ? 'wait' : 'pointer', overflowWrap: 'anywhere' }}
+      >
       <div style={{
         fontSize: 11,
         fontWeight: isUnread ? 700 : 400,
@@ -85,6 +199,22 @@ export function NotificationCard({ notification }: { notification: NotificationV
         <span style={{ color: '#444' }}>{'\u00B7'}</span>
         <span>{formatRelativeTime(notification.created_at)}</span>
       </div>
+      </button>
+      {(loading || message) && (
+        <div role="status" style={{ marginTop: 6, fontSize: 11, color: '#bbb', overflowWrap: 'anywhere' }}>
+          {loading ? 'Opening room context...' : message}
+        </div>
+      )}
+      {isUnread && (
+        <button type="button" onClick={handleAck} style={{ marginTop: 6, marginRight: 8, color: '#bbb', background: 'transparent', border: '1px solid #666680', borderRadius: 4, cursor: 'pointer' }}>
+          Mark read
+        </button>
+      )}
+      {message?.includes('unavailable') || message?.includes('cancelled') ? (
+        <button type="button" onClick={handleOpen} disabled={loading} style={{ marginTop: 6, marginRight: 8, color: '#bbb', background: 'transparent', border: '1px solid #666680', borderRadius: 4, cursor: 'pointer' }}>
+          Retry opening context
+        </button>
+      ) : null}
       {acceptLabel && (
         <button
           type="button"

--- a/ui/src/components/bridge/__tests__/BridgeNotifications.test.tsx
+++ b/ui/src/components/bridge/__tests__/BridgeNotifications.test.tsx
@@ -4,13 +4,56 @@
 // handler does not also fire). HXI no-emoji guard (#3). Real component; the
 // global fetch is stubbed.
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { act, render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import { NotificationCard } from '../BridgeNotifications';
 import cardSource from '../BridgeNotifications.tsx?raw';
-import type { NotificationView } from '../../../store/types';
+import { useStore } from '../../../store/useStore';
+import type { Agent, NotificationView } from '../../../store/types';
+import type { NotificationContext } from '../../sidebar/threadApi';
 
 const EMOJI_RE = /\p{Extended_Pictographic}/u;
+const initialStoreState = useStore.getState();
+
+function contextFixture(id = 'a'.repeat(64)): NotificationContext {
+  return {
+    kind: 'crew_session', notification_id: id, delivery_revision: 1,
+    thread: {
+      id: 'room', task_id: 'parent', title: 'Failed room', participants: ['host'],
+      project_id: null, pinned: false, archived: false, personality_override: null,
+      workspace_root: null, created_at: 1, last_active_at: 3, preprompt: null,
+      model: null, metadata: {},
+    },
+    session: {
+      task_id: 'parent', thread_id: 'room', goal: 'Prepare report', origin: 'captain',
+      originator_id: 'captain', facilitator_id: 'host', owner_ids: ['host'],
+      state: 'failed', revision: 1, success_criteria: ['Complete'], expected_deliverable: 'Report',
+      timestamps: { created_at: 1, transitioned_at: 3, started_at: 2, first_result_at: null, verified_at: null, completed_at: 3 },
+      progress: { total: 1, done: 0, failed: 1, active: 0, active_child: null },
+      last_result_summary: '', blocker: null, result: null, verification: null, duplicate_resume_count: 0,
+    },
+  };
+}
+
+function seedNavigation(): void {
+  const host: Agent = {
+    id: 'host', agentType: 'crew', callsign: 'Host', displayName: 'Host', pool: 'bridge',
+    state: 'active', confidence: 1, trust: 0.5, tier: 'domain', isCrew: true, position: [0, 0, 0],
+  };
+  useStore.setState({
+    agents: new Map([['host', host]]), activeProfileAgent: 'original-host',
+    activeProfileThreadId: 'original-room', activeThreadId: null,
+    threadIdByAgent: new Map([['host', 'host-dm']]), chatThreads: new Map(),
+    crewSessionsByParent: new Map(), notificationNavigation: null,
+    liveGeneration: 'b'.repeat(32), liveSequence: 0,
+  });
+}
+
+function StoreNotificationCard() {
+  const notification = useStore(state => state.notifications?.[0]);
+  return notification ? <NotificationCard notification={notification} /> : null;
+}
 
 function makeNotification(overrides: Partial<NotificationView> = {}): NotificationView {
   return {
@@ -37,6 +80,7 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
+  useStore.setState(initialStoreState, true);
   vi.unstubAllGlobals();
   vi.clearAllMocks();
 });
@@ -73,5 +117,263 @@ describe('AD-1053 NotificationCard accept affordance', () => {
     const { container } = render(<NotificationCard notification={n} />);
 
     expect(container.textContent ?? '').not.toMatch(EMOJI_RE);
+  });
+});
+
+describe('issue1373 Crew failure notification context', () => {
+  it.each(['pointer', 'Enter', 'Space'])('opens the exact validated room via %s with no writes', async (activation) => {
+    seedNavigation();
+    const context = contextFixture();
+    context.session = { ...context.session, revision: 2 };
+    fetchMock.mockResolvedValue(new Response(JSON.stringify(context), { status: 200 }));
+    render(<NotificationCard notification={makeNotification({ id: context.notification_id, action_url: 'javascript:unsafe()' })} />);
+    const button = screen.getByRole('button', { name: 'Open room context: t' });
+    const user = userEvent.setup();
+    if (activation === 'pointer') await user.click(button);
+    else {
+      button.focus();
+      await user.keyboard(activation === 'Enter' ? '{Enter}' : ' ');
+    }
+    await waitFor(() => expect(useStore.getState().activeProfileThreadId).toBe('room'));
+    expect(useStore.getState().activeProfileAgent).toBe('host');
+    expect(useStore.getState().chatThreads.get('room')).toEqual(context.thread);
+    expect(useStore.getState().crewSessionsByParent.get('parent')).toEqual(context.session);
+    expect(useStore.getState().threadIdByAgent.get('host')).toBe('host-dm');
+    expect(useStore.getState().notificationNavigation?.destination?.updated).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(`/api/notifications/${context.notification_id}/context`, expect.objectContaining({ method: 'GET', redirect: 'error' }));
+  });
+
+  it.each(['pointer', 'Enter', 'Space'])('opens completed delivery results via %s without acknowledgement or execution', async (activation) => {
+    seedNavigation();
+    const context = contextFixture();
+    context.session = {
+      ...context.session, state: 'done', last_result_summary: 'Verified report ready',
+      timestamps: { ...context.session.timestamps, first_result_at: 2, verified_at: 3 },
+      progress: { total: 1, done: 1, failed: 0, active: 0, active_child: null },
+      result: { artifact_id: 'verified-report', content_hash: 'c'.repeat(64), result_ref: 'd'.repeat(64), evidence_refs: ['e'.repeat(64)] },
+      verification: { verifier_agent_id: 'verifier', confidence: 0.95, critique: 'Accepted', accepted_count: 1, total_count: 1, convergence_rounds: 1 },
+    };
+    const notification = makeNotification({
+      id: context.notification_id, agent_type: 'crew_session', notification_type: 'info',
+      title: 'Crew session completed', detail: 'Open the existing crew room for details.',
+    });
+    useStore.setState({ notifications: [notification] });
+    const beforeNotifications = useStore.getState().notifications;
+    expect(context.session.revision).toBe(context.delivery_revision);
+    fetchMock.mockResolvedValue(new Response(JSON.stringify(context), { status: 200 }));
+    const activated = vi.fn();
+    render(<div onClickCapture={activated}><NotificationCard notification={notification} /></div>);
+    const button = screen.getByRole('button', { name: 'Open room context: Crew session completed' });
+    const user = userEvent.setup();
+    if (activation === 'pointer') await user.click(button);
+    else {
+      button.focus();
+      await user.keyboard(activation === 'Enter' ? '{Enter}' : ' ');
+    }
+    expect(activated).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    expect(fetchMock).toHaveBeenCalledWith(`/api/notifications/${context.notification_id}/context`, expect.objectContaining({ method: 'GET', redirect: 'error' }));
+    await waitFor(() => expect(screen.getByRole('status')).toHaveTextContent('Room context opened.'));
+    const state = useStore.getState();
+    expect(state.activeProfileThreadId).toBe(context.thread.id);
+    expect(state.activeProfileAgent).toBe('host');
+    expect(state.chatThreads.get(context.thread.id)).toEqual(context.thread);
+    expect(state.crewSessionsByParent.get(context.session.task_id)).toEqual(context.session);
+    expect(state.crewSessionsByParent.get(context.session.task_id)?.result).toEqual(context.session.result);
+    expect(state.crewSessionsByParent.get(context.session.task_id)?.verification).toEqual(context.session.verification);
+    expect(state.threadIdByAgent.get('host')).toBe('host-dm');
+    expect(state.notificationNavigation?.destination).toEqual({ hostId: 'host', threadId: 'room', parentId: 'parent', updated: false });
+    expect(state.notifications).toBe(beforeNotifications);
+    expect(state.notifications?.[0].acknowledged).toBe(false);
+    expect(screen.queryByRole('button', { name: 'Retry opening context' })).toBeNull();
+    expect(screen.queryByTestId('notification-accept')).toBeNull();
+    expect(fetchMock.mock.calls.map(([path, init]) => ({ path, method: init.method }))).toEqual([
+      { path: `/api/notifications/${context.notification_id}/context`, method: 'GET' },
+    ]);
+  });
+
+  it.each([401, 404, 409, 410, 503])('retains the source view on %s and retries only a read', async (status) => {
+    seedNavigation();
+    fetchMock.mockImplementation(async () => new Response('{}', { status }));
+    render(<NotificationCard notification={makeNotification({ id: 'a'.repeat(64) })} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Open room context: t' }));
+    await waitFor(() => expect(screen.getByRole('status')).toHaveTextContent('Context unavailable'));
+    fireEvent.click(screen.getByRole('button', { name: 'Retry opening context' }));
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(screen.getByRole('status')).toHaveTextContent('Context unavailable'));
+    expect(fetchMock.mock.calls.every(([, init]) => init.method === 'GET')).toBe(true);
+    expect(useStore.getState().activeProfileThreadId).toBe('original-room');
+  });
+
+  it.each(['malformed', 'network', 'removed-host', 'generic'])('honestly rejects %s context without navigation', async (failure) => {
+    seedNavigation();
+    const context = contextFixture();
+    if (failure === 'removed-host') context.thread.participants = ['removed'];
+    if (failure === 'network') fetchMock.mockRejectedValue(new Error('offline'));
+    else fetchMock.mockResolvedValue(new Response(JSON.stringify(failure === 'malformed'
+      ? { ...context, action_url: 'https://untrusted.invalid' } : context), { status: 200 }));
+    render(<NotificationCard notification={makeNotification({ id: failure === 'generic' ? 'n1' : context.notification_id })} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Open room context: t' }));
+    await waitFor(() => expect(screen.getByRole('status')).toHaveTextContent('Context unavailable'));
+    expect(useStore.getState().activeProfileThreadId).toBe('original-room');
+    expect(useStore.getState().chatThreads.size).toBe(0);
+    if (failure === 'generic') expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it.each(['sequence', 'generation', 'navigation', 'away-and-back', 'unmount'])('fences pending completion on %s', async (change) => {
+    seedNavigation();
+    const context = contextFixture();
+    let resolveContext: ((response: Response) => void) | undefined;
+    fetchMock.mockImplementation(() => new Promise<Response>(resolve => { resolveContext = resolve; }));
+    const view = render(<NotificationCard notification={makeNotification({ id: context.notification_id })} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Open room context: t' }));
+    expect(resolveContext).toBeTypeOf('function');
+    expect(screen.getByRole('status')).toHaveTextContent('Opening room context');
+    act(() => {
+      if (change === 'sequence') useStore.setState({ liveSequence: 3 });
+      if (change === 'generation') useStore.setState({ liveGeneration: 'c'.repeat(32) });
+      if (change === 'navigation' || change === 'away-and-back') useStore.getState().openAgentProfile('elsewhere');
+      if (change === 'away-and-back') useStore.getState().openGroupChatThread('original-host', 'original-room');
+    });
+    if (change === 'unmount') view.unmount();
+    await act(async () => { resolveContext!(new Response(JSON.stringify(context), { status: 200 })); });
+    expect(useStore.getState().activeProfileThreadId).toBe(change === 'sequence' ? 'room' : change === 'navigation' ? null : 'original-room');
+    expect(useStore.getState().chatThreads.has('room')).toBe(change === 'sequence');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('lets a newer card activation supersede an older pending response', async () => {
+    seedNavigation();
+    const first = contextFixture();
+    const second = contextFixture('d'.repeat(64));
+    second.thread.id = 'second-room';
+    second.session = { ...second.session, thread_id: 'second-room' };
+    const completions = new Map<string, (response: Response) => void>();
+    fetchMock.mockImplementation((path: string) => new Promise<Response>(resolve => { completions.set(path, resolve); }));
+    render(<>
+      <NotificationCard notification={makeNotification({ id: first.notification_id, title: 'First' })} />
+      <NotificationCard notification={makeNotification({ id: second.notification_id, title: 'Second' })} />
+    </>);
+    fireEvent.click(screen.getByRole('button', { name: 'Open room context: First' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Open room context: Second' }));
+    expect(completions.size).toBe(2);
+    await act(async () => {
+      completions.get(`/api/notifications/${second.notification_id}/context`)!(new Response(JSON.stringify(second)));
+      completions.get(`/api/notifications/${first.notification_id}/context`)!(new Response(JSON.stringify(first)));
+    });
+    expect(useStore.getState().activeProfileThreadId).toBe('second-room');
+    expect(useStore.getState().chatThreads.has('room')).toBe(false);
+  });
+
+  it('cancels when the mounted Bridge source hides, even if reopened before completion', async () => {
+    seedNavigation();
+    const context = contextFixture();
+    let finish: ((response: Response) => void) | undefined;
+    fetchMock.mockImplementation(() => new Promise<Response>(resolve => { finish = resolve; }));
+    const view = render(<div data-testid="bridge-source" style={{ pointerEvents: 'auto' }}>
+      <NotificationCard notification={makeNotification({ id: context.notification_id })} />
+    </div>);
+    fireEvent.click(screen.getByRole('button', { name: 'Open room context: t' }));
+    expect(finish).toBeTypeOf('function');
+    view.rerender(<div data-testid="bridge-source" style={{ pointerEvents: 'none' }}>
+      <NotificationCard notification={makeNotification({ id: context.notification_id })} />
+    </div>);
+    await waitFor(() => expect(screen.getByRole('status')).toHaveTextContent('cancelled'));
+    view.rerender(<div data-testid="bridge-source" style={{ pointerEvents: 'auto' }}>
+      <NotificationCard notification={makeNotification({ id: context.notification_id })} />
+    </div>);
+    await act(async () => { finish!(new Response(JSON.stringify(context))); });
+    expect(useStore.getState().activeProfileThreadId).toBe('original-room');
+    expect(useStore.getState().chatThreads.size).toBe(0);
+  });
+
+  it('marks read through a separate native control without opening or accepting', () => {
+    render(<NotificationCard notification={makeNotification()} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Mark read' }));
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith('/api/notifications/n1/ack', { method: 'POST' });
+  });
+
+  it('requests governed context for the activated notification without accepting or mutating work', async () => {
+    const originalState = useStore.getState();
+    const notification = makeNotification({
+      id: 'a'.repeat(64),
+      agent_id: 'operations-officer',
+      agent_type: 'crew_session',
+      department: 'operations',
+      notification_type: 'error',
+      title: 'Crew session failed',
+      detail: 'Open the existing crew room for details.',
+      action_url: 'thread:failed-crew-room',
+    });
+    const contextPath = `/api/notifications/${notification.id}/context`;
+    const ackPath = `/api/notifications/${notification.id}/ack`;
+    const requests: { path: string; method: string }[] = [];
+    const activated = vi.fn();
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const path = input instanceof Request ? input.url : String(input);
+      const method = (init?.method ?? (input instanceof Request ? input.method : 'GET')).toUpperCase();
+      requests.push({ path, method });
+      if (path === '/api/recreation/active' && method === 'GET') {
+        return new Response('{}', { status: 200 });
+      }
+      if (path === contextPath && method === 'GET') {
+        return new Response(JSON.stringify({ detail: 'Notification context unavailable' }), {
+          status: 404,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (path === ackPath && method === 'POST') {
+        return new Response('{}', { status: 200 });
+      }
+      throw new Error(`Unexpected notification request: ${method} ${path}`);
+    });
+
+    try {
+      useStore.setState({
+        notifications: null,
+        liveGeneration: null,
+        liveSequence: 0,
+        activeProfileAgent: 'original-host',
+        activeProfileThreadId: 'original-room',
+      });
+      useStore.getState().handleEvent({
+        type: 'state_snapshot',
+        data: {
+          agents: [], connections: [], pools: [], notifications: [notification],
+          system_mode: 'active', tc_n: 0, routing_entropy: 0,
+        },
+        timestamp: 100,
+        stream: { generation: 'b'.repeat(32), sequence: 0 },
+      });
+      expect(useStore.getState().notifications).toEqual([notification]);
+      render(<div onClickCapture={activated}><StoreNotificationCard /></div>);
+      const title = screen.getByText(notification.title);
+      expect(title).toBeVisible();
+      expect(screen.queryByTestId('notification-accept')).toBeNull();
+      requests.length = 0;
+
+      fireEvent.click(title);
+
+      expect(activated).toHaveBeenCalledTimes(1);
+      expect(requests.filter(request => request.method !== 'GET')).toEqual(
+        requests.filter(request => request.path === ackPath && request.method === 'POST'),
+      );
+      await waitFor(() => {
+        expect(requests).toContainEqual({ path: contextPath, method: 'GET' });
+      });
+      expect(requests.every(request =>
+        (request.path === contextPath && request.method === 'GET')
+        || (request.path === ackPath && request.method === 'POST'),
+      )).toBe(true);
+      expect(useStore.getState().activeProfileAgent).toBe('original-host');
+      expect(useStore.getState().activeProfileThreadId).toBe('original-room');
+    } finally {
+      cleanup();
+      useStore.setState(originalState, true);
+    }
   });
 });

--- a/ui/src/components/chats/__tests__/ChatsPanel.test.tsx
+++ b/ui/src/components/chats/__tests__/ChatsPanel.test.tsx
@@ -7,9 +7,10 @@
 // real-fixture style, no MagicMock at the store boundary. Includes the HXI
 // no-emoji guard. Test #1 FLIPS the AD-919 contract: 1:1s are now INCLUDED.
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { render, screen, fireEvent, cleanup, waitFor, within, type RenderResult } from '@testing-library/react';
+import { act, render, screen, fireEvent, cleanup, waitFor, within, type RenderResult } from '@testing-library/react';
 import { useStore, type AD791aChatThreadView } from '../../../store/useStore';
-import type { Agent, CrewSessionSummaryProjection, RoomSummary } from '../../../store/types';
+import type { Agent, CrewSessionSummaryProjection, RoomSummary, WSEvent } from '../../../store/types';
+import notificationFixture from '../../../../e2e/fixtures/notification-navigation.json';
 
 vi.mock('../../sidebar/threadApi', () => ({
   listThreads: vi.fn(),
@@ -120,9 +121,71 @@ afterEach(() => {
     roomSummariesByThread: new Map(),
   });
   vi.clearAllMocks();
+  useStore.setState({ notifications: null, liveGeneration: null, liveSequence: 0 });
 });
 
 describe('AD-931 ChatsPanel', () => {
+  it('keeps failed rooms and synthetic blocked work discoverable after notification acknowledgement and pruning', async () => {
+    const failedRoom = notificationFixture.context.thread;
+    const failedSummary = notificationFixture.summaries.summaries[failedRoom.id as 'notification-navigation-1'] as RoomSummary;
+    if (!('session' in failedSummary) || !failedSummary.session) {
+      throw new Error('Producer fixture must contain a crew session summary');
+    }
+    const blocked: CrewSessionSummaryProjection = {
+      ...failedSummary.session,
+      task_id: 'task-1', thread_id: 't1', goal: 'Synthetic blocked retention case',
+      state: 'blocked_needs_captain', facilitator_id: 'mccoy', owner_ids: ['mccoy', 'scotty'],
+      blocker: { reason: 'Choose route', since: 10, duration_seconds: 30 }, needs_attention: true,
+    };
+    const summaries: Record<string, RoomSummary> = {
+      [failedRoom.id]: failedSummary,
+      t1: { outputs: 0, steps_total: 0, steps_done: 0, topic: blocked.goal, session: blocked },
+    };
+    useStore.setState({ liveGeneration: null, liveSequence: 0, notifications: null });
+    await renderOpen([...ALL, failedRoom], [
+      ...AGENTS,
+      ...failedRoom.participants.map(id => mkAgent({ id, callsign: id })),
+    ], summaries);
+    const dispatch = (type: string, data: Record<string, unknown>, sequence: number): void => {
+      const event: WSEvent = { type, data, timestamp: 200 + sequence, stream: { generation: 'a'.repeat(32), sequence } };
+      act(() => useStore.getState().handleEvent(event));
+    };
+    dispatch('state_snapshot', {
+      agents: [...AGENTS, ...failedRoom.participants.map(id => mkAgent({ id, callsign: id }))]
+        .map(agent => ({ ...agent, agent_type: agent.agentType, display_name: agent.displayName })),
+      connections: [], pools: [], system_mode: 'active', tc_n: 0, routing_entropy: 0,
+      notifications: notificationFixture.event.data.notifications,
+    }, 0);
+    await screen.findByTestId(`room-session-${failedRoom.id}`);
+    expect(useStore.getState().notifications).toHaveLength(1);
+    const sessionsBefore = new Map(useStore.getState().crewSessionSummariesByThread);
+    const acknowledged = { ...notificationFixture.event.data.notification, acknowledged: true };
+    dispatch('notification_ack', { notifications: [acknowledged], unread_count: 0 }, 1);
+    expect(useStore.getState().notifications).toEqual([acknowledged]);
+    expect(screen.getByTestId(`room-session-${failedRoom.id}`)).toHaveTextContent('failed');
+
+    const syntheticRetained = Array.from({ length: 50 }, (_, index) => ({
+      ...acknowledged, id: `synthetic-retained-${index}`, title: `Retained ${index}`,
+    }));
+    dispatch('notification_snapshot', {
+      notifications: [acknowledged, ...syntheticRetained], unread_count: 0,
+    }, 2);
+    expect(useStore.getState().notifications).toHaveLength(51);
+    dispatch('notification_ack', { notifications: syntheticRetained, unread_count: 0 }, 3);
+    expect(useStore.getState().notifications).toHaveLength(50);
+    expect(useStore.getState().notifications?.some(item => item.id === acknowledged.id)).toBe(false);
+    expect(screen.getByTestId(`room-session-${failedRoom.id}`)).toHaveTextContent('failed');
+    expect(screen.getByTestId(`room-session-${failedRoom.id}`)).toHaveTextContent(
+      notificationFixture.context.session.last_result_summary,
+    );
+    fireEvent.click(screen.getByTestId('rooms-filter-needs'));
+    expect(screen.getByTestId('chat-row-t1')).toHaveAttribute('data-needs-attention', 'true');
+    expect(screen.getByTestId('room-session-t1')).toHaveTextContent('blocked_needs_captain');
+    expect(useStore.getState().crewSessionSummariesByThread).toEqual(sessionsBefore);
+    expect(useStore.getState().activeProfileThreadId).toBeNull();
+    expect(addParticipant).not.toHaveBeenCalled();
+  });
+
   it('updates live room fields from the authoritative store map without reopen', async () => {
     await renderOpen();
     const liveSummary: RoomSummary = {

--- a/ui/src/components/profile/AgentProfilePanel.tsx
+++ b/ui/src/components/profile/AgentProfilePanel.tsx
@@ -34,6 +34,13 @@ const DEPT_COLORS: Record<string, string> = {
   bridge: '#d0a030',
 };
 
+function readViewport(): { w: number; h: number } {
+  return {
+    w: Number.isFinite(window.innerWidth) ? Math.max(0, window.innerWidth) : 0,
+    h: Number.isFinite(window.innerHeight) ? Math.max(0, window.innerHeight) : 0,
+  };
+}
+
 export function AgentProfilePanel() {
   const activeProfileAgent = useStore((s) => s.activeProfileAgent);
   const agents = useStore((s) => s.agents);
@@ -70,16 +77,26 @@ export function AgentProfilePanel() {
     : activeProfileAgent;
 
   const [activeTab, setActiveTab] = useState<ProfileTab>('chat');
+  const notificationNavigation = useStore(state => state.notificationNavigation);
+  const liveGeneration = useStore(state => state.liveGeneration);
+  useEffect(() => {
+    const destination = notificationNavigation?.destination;
+    if (destination && notificationNavigation.generation === liveGeneration
+      && destination.threadId === activeProfileThreadId && destination.hostId === agentId) {
+      setActiveTab('chat');
+    }
+  }, [notificationNavigation, liveGeneration, activeProfileThreadId, agentId]);
   const [profileData, setProfileData] = useState<AgentProfileData | null>(null);
   const [isDragging, setIsDragging] = useState(false);
   // Resizable panel state — persisted in localStorage so the captain's
   // preferred chat-window size survives reloads.
-  const [size, setSize] = useState(() => {
+  const [size, setSize] = useState<{ w: number; h: number }>(() => {
     try {
       const stored = localStorage.getItem('hxi_profile_panel_size');
       if (stored) {
         const parsed = JSON.parse(stored);
-        if (typeof parsed.w === 'number' && typeof parsed.h === 'number') return parsed;
+        if (parsed && Number.isFinite(parsed.w) && parsed.w > 0
+          && Number.isFinite(parsed.h) && parsed.h > 0) return { w: parsed.w, h: parsed.h };
       }
     } catch (_e) { /* fall through to default */ }
     return { w: 420, h: 580 };
@@ -87,8 +104,18 @@ export function AgentProfilePanel() {
   useEffect(() => {
     localStorage.setItem('hxi_profile_panel_size', JSON.stringify(size));
   }, [size]);
+  const [viewport, setViewport] = useState(readViewport);
+  useEffect(() => {
+    const onResize = () => setViewport(readViewport());
+    window.addEventListener('resize', onResize);
+    return () => window.removeEventListener('resize', onResize);
+  }, []);
+  const width = Math.min(size.w, viewport.w);
+  const height = Math.min(size.h, viewport.h);
+  const left = Math.max(0, Math.min(viewport.w - width, Number.isFinite(pos.x) ? pos.x : 0));
+  const top = Math.max(0, Math.min(viewport.h - height, Number.isFinite(pos.y) ? pos.y : 0));
   const [isResizing, setIsResizing] = useState(false);
-  const resizeStart = useRef({ x: 0, y: 0, w: 420, h: 580 });
+  const resizeStart = useRef({ x: 0, y: 0, w: 420, h: 580, left: 0, top: 0 });
   // AD-721: avatar popout state.
   const [avatarOpen, setAvatarOpen] = useState(false);
   const [avatarsEnabled, setAvatarsEnabled] = useState(false);
@@ -149,14 +176,14 @@ export function AgentProfilePanel() {
   // Drag handlers
   const onMouseDown = useCallback((e: React.MouseEvent) => {
     setIsDragging(true);
-    dragOffset.current = { x: e.clientX - pos.x, y: e.clientY - pos.y };
-  }, [pos]);
+    dragOffset.current = { x: e.clientX - left, y: e.clientY - top };
+  }, [left, top]);
 
   useEffect(() => {
     if (!isDragging) return;
     const onMove = (e: MouseEvent) => {
-      const newX = Math.max(0, Math.min(window.innerWidth - 420, e.clientX - dragOffset.current.x));
-      const newY = Math.max(0, Math.min(window.innerHeight - 100, e.clientY - dragOffset.current.y));
+      const newX = Math.max(0, Math.min(viewport.w - width, e.clientX - dragOffset.current.x));
+      const newY = Math.max(0, Math.min(viewport.h - height, e.clientY - dragOffset.current.y));
       useStore.getState().setProfilePanelPos({ x: newX, y: newY });
     };
     const onUp = () => setIsDragging(false);
@@ -166,23 +193,26 @@ export function AgentProfilePanel() {
       window.removeEventListener('mousemove', onMove);
       window.removeEventListener('mouseup', onUp);
     };
-  }, [isDragging]);
+  }, [isDragging, viewport.w, viewport.h, width, height]);
 
   // Resize handlers — bottom-right corner drags to resize.
   const onResizeMouseDown = useCallback((e: React.MouseEvent) => {
     setIsResizing(true);
-    resizeStart.current = { x: e.clientX, y: e.clientY, w: size.w, h: size.h };
+    resizeStart.current = { x: e.clientX, y: e.clientY, w: width, h: height, left, top };
+    useStore.getState().setProfilePanelPos({ x: left, y: top });
     e.preventDefault();
     e.stopPropagation();
-  }, [size]);
+  }, [width, height, left, top]);
 
   useEffect(() => {
     if (!isResizing) return;
     const onMove = (e: MouseEvent) => {
       const dw = e.clientX - resizeStart.current.x;
       const dh = e.clientY - resizeStart.current.y;
-      const nw = Math.max(320, Math.min(window.innerWidth - 40, resizeStart.current.w + dw));
-      const nh = Math.max(360, Math.min(window.innerHeight - 40, resizeStart.current.h + dh));
+      const availableWidth = Math.max(0, viewport.w - resizeStart.current.left);
+      const availableHeight = Math.max(0, viewport.h - resizeStart.current.top);
+      const nw = Math.min(availableWidth, Math.max(320, resizeStart.current.w + dw));
+      const nh = Math.min(availableHeight, Math.max(360, resizeStart.current.h + dh));
       setSize({ w: nw, h: nh });
     };
     const onUp = () => setIsResizing(false);
@@ -192,7 +222,7 @@ export function AgentProfilePanel() {
       window.removeEventListener('mousemove', onMove);
       window.removeEventListener('mouseup', onUp);
     };
-  }, [isResizing]);
+  }, [isResizing, viewport.w, viewport.h]);
 
   if (!agentId || !agent) return null;
 
@@ -226,16 +256,17 @@ export function AgentProfilePanel() {
     <div
       style={{
         position: 'fixed',
-        left: pos.x,
-        top: pos.y,
-        width: size.w,
-        height: size.h,
+        left,
+        top,
+        width,
+        height,
+        boxSizing: 'border-box',
         background: 'rgba(10, 10, 18, 0.92)',
         backdropFilter: 'blur(16px)',
         WebkitBackdropFilter: 'blur(16px)',
         border: '1px solid rgba(240, 176, 96, 0.2)',
         borderRadius: 12,
-        zIndex: 25,
+        zIndex: 27,
         display: 'flex',
         flexDirection: 'column',
         fontFamily: "'JetBrains Mono', monospace",
@@ -527,7 +558,10 @@ export function AgentProfilePanel() {
         {visibleTabs.map(({ key, label }) => (
           <button
             key={key}
-            onClick={() => setActiveTab(key)}
+            onClick={() => {
+              useStore.getState().setNotificationNavigation(null);
+              setActiveTab(key);
+            }}
             style={{
               flex: 1,
               background: 'none',

--- a/ui/src/components/profile/ProfileChatTab.tsx
+++ b/ui/src/components/profile/ProfileChatTab.tsx
@@ -242,14 +242,35 @@ const PTT_TTS_WATCHDOG_MS = 45000;
 // counter is enough because the key never leaves the document.
 let _speechOwnerSeq = 0;
 
+const EMPTY_COMPOSER_ATTACHMENTS: ChatAttachment[] = [];
+
 export function ProfileChatTab({ agentId, threadId }: Props) {
   const conversation = useStore((s) => s.agentConversations.get(agentId));
+  const activeThreadId = useStore((state) =>
+    resolveProfileThreadId(threadId, state.activeProfileThreadId, state.threadIdByAgent, agentId),
+  );
+  const composerOwner = activeThreadId ? `thread:${activeThreadId}` : `agent:${agentId}`;
+  const composerDraft = useStore(state => state.composerDrafts.get(composerOwner));
+  const input = composerDraft?.text ?? '';
+  const pendingAttachments = composerDraft?.attachments ?? EMPTY_COMPOSER_ATTACHMENTS;
+  const attachError = composerDraft?.error ?? null;
+  const pendingUploads = composerDraft?.pendingUploads ?? 0;
+  const setInput = useCallback((text: string): void => {
+    useStore.getState().updateComposerDraft(composerOwner, draft => ({ ...draft, text }));
+  }, [composerOwner]);
+  const setPendingAttachments = useCallback((update: React.SetStateAction<ChatAttachment[]>): void => {
+    useStore.getState().updateComposerDraft(composerOwner, draft => ({
+      ...draft, attachments: typeof update === 'function' ? update(draft.attachments) : update,
+    }));
+  }, [composerOwner]);
+  const setAttachError = useCallback((error: string | null): void => {
+    useStore.getState().updateComposerDraft(composerOwner, draft => ({ ...draft, error }));
+  }, [composerOwner]);
   const speechOwnerRef = useRef<string | null>(null);
   if (speechOwnerRef.current === null) {
     speechOwnerRef.current = `profile-chat-${++_speechOwnerSeq}`;
   }
   const speechOwner = speechOwnerRef.current;
-  const [input, setInput] = useState('');
   const [sending, setSending] = useState(false);
   const [listening, setListening] = useState(false);
   // BF-294b — real-time amplitude meter for MicIndicator (0..1, smoothed
@@ -333,8 +354,6 @@ export function ProfileChatTab({ agentId, threadId }: Props) {
       setProcessing(false);
     };
   }, []);
-  const [pendingAttachments, setPendingAttachments] = useState<ChatAttachment[]>([]);
-  const [attachError, setAttachError] = useState<string | null>(null);
   const [screenMode, setScreenMode] = useState<ScreenMode>(() => loadScreenMode(agentId));
   const [screenMenuOpen, setScreenMenuOpen] = useState(false);
   const [screenShareInFlight, setScreenShareInFlight] = useState(false);
@@ -620,9 +639,6 @@ export function ProfileChatTab({ agentId, threadId }: Props) {
   // per-agent default in threadIdByAgent).
   // AD-937: 3-way precedence — prop > group override > per-agent 1:1 — so a
   // group opened via the override is addressed without touching threadIdByAgent.
-  const activeThreadId = useStore((s) =>
-    resolveProfileThreadId(threadId, s.activeProfileThreadId, s.threadIdByAgent, agentId),
-  );
   const liveThreadRefresh = useStore((s) => s.liveThreadRefresh);
   const liveRepairEpoch = useStore((s) => s.liveRepairEpoch);
   const transcriptRequestRef = useRef(0);
@@ -850,6 +866,42 @@ export function ProfileChatTab({ agentId, threadId }: Props) {
     ? boundCrewSession.parentId
     : null;
   const crewPanelParentId = workspaceThread?.task_id ?? boundCrewParentId;
+  const notificationNavigation = useStore(state => state.notificationNavigation);
+  const notificationGeneration = useStore(state => state.liveGeneration);
+  const [notificationAnnouncement, setNotificationAnnouncement] = useState<{
+    threadId: string; generation: string | null; text: string;
+  } | null>(null);
+  useEffect(() => {
+    const request = notificationNavigation;
+    const destination = request?.destination;
+    if (!request || !destination || destination.threadId !== activeThreadId
+      || destination.parentId !== crewPanelParentId || destination.hostId !== agentId
+      || request.generation !== notificationGeneration) return;
+    let cancelled = false;
+    const focus = (): void => {
+      const current = useStore.getState();
+      if (cancelled || current.notificationNavigation !== request
+        || current.liveGeneration !== request.generation
+        || current.activeProfileThreadId !== destination.threadId
+        || current.activeProfileAgent !== destination.hostId) return;
+      const band = crewSessionBandRef.current;
+      if (!band?.isConnected) return;
+      band.focus();
+      setNotificationAnnouncement({
+        threadId: destination.threadId, generation: request.generation,
+        text: destination.updated
+          ? 'Room context updated since this notification. Showing current session state.'
+          : 'Notification room context opened. Showing current session state.',
+      });
+      current.setNotificationNavigation(null);
+    };
+    const frame = typeof requestAnimationFrame === 'function' ? requestAnimationFrame(focus) : null;
+    if (frame === null) queueMicrotask(focus);
+    return () => {
+      cancelled = true;
+      if (frame !== null) cancelAnimationFrame(frame);
+    };
+  }, [notificationNavigation, notificationGeneration, activeThreadId, crewPanelParentId, agentId]);
   const visibleCrewRetryCommand = crewRetryCommand?.threadId === activeThreadId
     ? crewRetryCommand
     : null;
@@ -1330,7 +1382,7 @@ export function ProfileChatTab({ agentId, threadId }: Props) {
         try { el.setSelectionRange(text.length, text.length); } catch { /* ignore */ }
       }
     });
-  }, [agentId, pendingDraft, consumeChatDraft]);
+  }, [agentId, pendingDraft, consumeChatDraft, setInput]);
 
   // AD-718: Fetch per-agent voice profile (Tier-2 log-and-degrade on failure).
   // Refetches when ProfileInfoTab dispatches `voice-profile-updated` for this agent.
@@ -1696,7 +1748,7 @@ export function ProfileChatTab({ agentId, threadId }: Props) {
     } finally {
       setSending(false);
     }
-  }, [agentId, threadId, sending, seedMemories, voiceProfile, pendingAttachments, speakMeetingReplies, activeThreadId, isOutputAudioEnabledNow, isCallLiveNow, speechOwner]);
+  }, [agentId, threadId, sending, seedMemories, voiceProfile, pendingAttachments, speakMeetingReplies, activeThreadId, isOutputAudioEnabledNow, isCallLiveNow, speechOwner, setInput, setPendingAttachments]);
 
   // AD-985: keep the send ref current so the meeting open-mic's
   // ``submitTranscript`` routes through the live group-fan-out path.
@@ -1908,10 +1960,14 @@ export function ProfileChatTab({ agentId, threadId }: Props) {
   };
 
   async function uploadAttachment(file: File): Promise<void> {
+    const uploadOwner = composerOwner;
     if (file.size > MAX_ATTACHMENT_BYTES) {
       setAttachError(`Too large: ${file.name} (${file.size} bytes)`);
       return;
     }
+    useStore.getState().updateComposerDraft(uploadOwner, draft => ({
+      ...draft, pendingUploads: draft.pendingUploads + 1,
+    }));
     try {
       const fd = new FormData();
       fd.append('file', file, file.name);
@@ -1927,6 +1983,10 @@ export function ProfileChatTab({ agentId, threadId }: Props) {
       setAttachError(null);
     } catch (err) {
       setAttachError(`Upload error: ${(err as Error).message}`);
+    } finally {
+      useStore.getState().updateComposerDraft(uploadOwner, draft => ({
+        ...draft, pendingUploads: Math.max(0, draft.pendingUploads - 1),
+      }));
     }
   }
 
@@ -1999,6 +2059,12 @@ export function ProfileChatTab({ agentId, threadId }: Props) {
       {/* AD-917: in-chat group controls (rename / participants / add). Renders
           nothing until a thread exists. Mounted above the message list. */}
       {activeThreadId && <GroupChatHeader threadId={activeThreadId} />}
+      {notificationAnnouncement && notificationAnnouncement.threadId === activeThreadId
+        && notificationAnnouncement.generation === notificationGeneration && (
+        <div role="status" style={{ padding: '6px 12px', color: '#bbb', fontSize: 11, overflowWrap: 'anywhere' }}>
+          {notificationAnnouncement.text}
+        </div>
+      )}
       {/* AD-932: discoverable "+ Add people" on a fresh/empty 1:1 (no thread
           yet). Mutually exclusive with GroupChatHeader; materializes the thread
           so the header (+ its picker) takes over on the next render. */}
@@ -2099,6 +2165,9 @@ export function ProfileChatTab({ agentId, threadId }: Props) {
       )}
 
       {/* Attachment chips */}
+      {pendingUploads > 0 && (
+        <div role="status" style={{ padding: '6px 12px', color: '#bbb', fontSize: 11 }}>Uploading attachments...</div>
+      )}
       {(pendingAttachments.length > 0 || attachError) && (
         <div style={{
           padding: '4px 12px',

--- a/ui/src/components/profile/__tests__/ProfileChatTab.crewSession.test.tsx
+++ b/ui/src/components/profile/__tests__/ProfileChatTab.crewSession.test.tsx
@@ -129,7 +129,7 @@ type NetworkOptions = {
   }>>;
 };
 
-function installNetwork(options: NetworkOptions): ReturnType<typeof vi.fn> {
+function installNetwork(options: NetworkOptions): ReturnType<typeof vi.fn<typeof fetch>> {
   const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
     const url = String(input);
     const method = init?.method ?? 'GET';
@@ -201,6 +201,8 @@ function seed(threadRows: AD791aChatThreadView[]): void {
     callAudioEnabled: true,
     typingAgent: null,
     chatDrafts: {},
+    composerDrafts: new Map(),
+    notificationNavigation: null,
     liveGeneration: null,
     liveSequence: 0,
     liveRepairEpoch: 0,
@@ -222,6 +224,104 @@ afterEach(() => {
   vi.clearAllMocks();
   localStorage.clear();
   seed([]);
+});
+
+describe('issue1373 room-owned composers and notification focus', () => {
+  it.each(['host', 'peer'])('restores text and attachments after switching to %s and remounting', async (nextHost) => {
+    seed([thread('t1', null), thread('t2', null)]);
+    const baseFetch = installNetwork({ details: {} });
+    vi.stubGlobal('fetch', vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      if (String(input) === '/api/chat/attachments/multipart') {
+        return Promise.resolve(json({ attachment_id: SHA_A, url: '/attachment', sha256: SHA_A, mime: 'text/plain', size_bytes: 5 }));
+      }
+      return baseFetch(input, init);
+    }));
+    const view = render(<ProfileChatTab agentId="host" threadId="t1" />);
+    fireEvent.change(screen.getByPlaceholderText('Message...'), { target: { value: 'First unsent message' } });
+    const picker = view.container.querySelector('input[type="file"]');
+    expect(picker).not.toBeNull();
+    fireEvent.change(picker!, { target: { files: [new File(['draft'], 'draft.txt', { type: 'text/plain' })] } });
+    expect(await screen.findByText('draft.txt')).toBeVisible();
+
+    view.rerender(<ProfileChatTab agentId={nextHost} threadId="t2" />);
+    expect(screen.getByPlaceholderText('Message...')).toHaveValue('');
+    expect(screen.queryByText('draft.txt')).toBeNull();
+    fireEvent.change(screen.getByPlaceholderText('Message...'), { target: { value: 'Second unsent message' } });
+    view.unmount();
+    const returned = render(<ProfileChatTab agentId="host" threadId="t1" />);
+    expect(screen.getByPlaceholderText('Message...')).toHaveValue('First unsent message');
+    expect(screen.getByText('draft.txt')).toBeVisible();
+    fireEvent.click(screen.getByRole('button', { name: 'remove attachment' }));
+    expect(screen.queryByText('draft.txt')).toBeNull();
+    returned.rerender(<ProfileChatTab agentId={nextHost} threadId="t2" />);
+    expect(screen.getByPlaceholderText('Message...')).toHaveValue('Second unsent message');
+  });
+
+  it.each([200, 500])('keeps late upload completion (%s) with its unmounted owner', async (status) => {
+    seed([thread('t1', null), thread('t2', null)]);
+    const baseFetch = installNetwork({ details: {} });
+    let finishUpload: ((response: Response) => void) | undefined;
+    const network = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      if (String(input) === '/api/chat/attachments/multipart') {
+        return new Promise<Response>(resolve => { finishUpload = resolve; });
+      }
+      return baseFetch(input, init);
+    });
+    vi.stubGlobal('fetch', network);
+    const first = render(<ProfileChatTab agentId="host" threadId="t1" />);
+    const picker = first.container.querySelector('input[type="file"]');
+    expect(picker).not.toBeNull();
+    fireEvent.change(picker!, { target: { files: [new File(['late'], 'late.txt', { type: 'text/plain' })] } });
+    expect(finishUpload).toBeTypeOf('function');
+    expect(screen.getByText('Uploading attachments...')).toBeVisible();
+    first.unmount();
+    const second = render(<ProfileChatTab agentId="peer" threadId="t2" />);
+    await act(async () => {
+      finishUpload!(json(status === 200
+        ? { attachment_id: SHA_A, url: '/attachment', sha256: SHA_A, mime: 'text/plain', size_bytes: 4 }
+        : { error: 'Upload rejected' }, status));
+    });
+    expect(screen.queryByText('late.txt')).toBeNull();
+    expect(screen.queryByText('Upload failed: Upload rejected')).toBeNull();
+    expect(screen.queryByText('Uploading attachments...')).toBeNull();
+    expect(useStore.getState().composerDrafts.get('thread:t1')?.pendingUploads).toBe(0);
+    second.rerender(<ProfileChatTab agentId="host" threadId="t1" />);
+    expect(await screen.findByText(status === 200 ? 'late.txt' : 'Upload failed: Upload rejected')).toBeVisible();
+    expect(network.mock.calls.filter(([, init]) => init?.method === 'POST')).toHaveLength(1);
+  });
+
+  it('keeps the pre-thread agent draft separate and preserves insertion semantics', () => {
+    seed([thread('t1', null)]);
+    installNetwork({ details: {} });
+    const view = render(<ProfileChatTab agentId="host" />);
+    fireEvent.change(screen.getByPlaceholderText('Message...'), { target: { value: 'Before thread creation' } });
+    view.rerender(<ProfileChatTab agentId="host" threadId="t1" />);
+    expect(screen.getByPlaceholderText('Message...')).toHaveValue('');
+    act(() => useStore.getState().setChatDraft('host', 'Inserted text'));
+    expect(screen.getByPlaceholderText('Message...')).toHaveValue('Inserted text');
+    expect(useStore.getState().chatDrafts.host).toBeUndefined();
+    view.rerender(<ProfileChatTab agentId="host" />);
+    expect(screen.getByPlaceholderText('Message...')).toHaveValue('Before thread creation');
+  });
+
+  it('focuses the hydrated matching session and announces updated state without writes', async () => {
+    const detail = projection('p1', 't1', 'blocked_needs_captain');
+    seed([thread('t1', 'p1')]);
+    const network = installNetwork({ details: { p1: detail } });
+    const state = useStore.getState();
+    state.hydrateCrewSession('p1', detail);
+    state.openGroupChatThread('host', 't1');
+    state.setNotificationNavigation({
+      requestId: Symbol('notification'), generation: null,
+      destination: { hostId: 'host', threadId: 't1', parentId: 'p1', updated: true },
+    });
+    render(<ProfileChatTab agentId="host" threadId="t1" />);
+    expect(await screen.findByText('Room context updated since this notification. Showing current session state.')).toBeVisible();
+    expect(document.activeElement?.getAttribute('tabindex')).toBe('-1');
+    expect(document.activeElement?.textContent).toContain(detail.goal);
+    expect(useStore.getState().notificationNavigation).toBeNull();
+    expect(network.mock.calls.filter(([, init]) => ['POST', 'PATCH', 'DELETE'].includes(init?.method ?? 'GET'))).toEqual([]);
+  });
 });
 
 describe('AD-1132 ProfileChatTab CrewSession integration', () => {
@@ -372,6 +472,30 @@ describe('AD-1132 ProfileChatTab CrewSession integration', () => {
     expect(screen.queryByRole('button', { name: 'Retry blocked CrewSession work' })).toBeNull();
     expect(screen.queryByRole('dialog')).toBeNull();
     expect(fetchMock.mock.calls.filter(([, init]) => ['POST', 'PATCH', 'DELETE'].includes(String(init?.method ?? 'GET')))).toEqual([]);
+  });
+
+  it.each([
+    'crew_worker_unavailable', 'child_execution_interrupted', 'recovery_retry_exhausted',
+  ])('shows recovery for synthetic blocked context %s without executing it', async (reason) => {
+    const room = thread('t1', 'p1');
+    const blocked = projection('p1', 't1', 'blocked_needs_captain', reason);
+    seed([room]);
+    const fetchMock = installNetwork({ details: { p1: blocked } });
+    render(<ProfileChatTab agentId="host" threadId="t1" />);
+
+    const panel = await screen.findByTestId('crew-collaboration-panel');
+    await waitFor(() => expect(panel).toHaveAttribute('aria-busy', 'false'));
+    expect(panel).toHaveAttribute('data-state', 'blocked_needs_captain');
+    expect(screen.getByTestId('crew-session-blocker')).toHaveTextContent('Captain action required');
+    const recovery = screen.getByRole('button', { name: 'Retry blocked CrewSession work' });
+    expect(recovery).toBeVisible();
+    expect(recovery).toBeEnabled();
+    expect(screen.queryByRole('dialog')).toBeNull();
+    expect(useStore.getState().crewSessionsByParent.get('p1')).toEqual(blocked);
+    expect(fetchMock.mock.calls.some(([input]) => String(input) === '/api/crew-tasks/p1')).toBe(true);
+    expect(fetchMock.mock.calls.filter(([, init]) =>
+      ['POST', 'PATCH', 'PUT', 'DELETE'].includes(init?.method ?? 'GET'),
+    )).toEqual([]);
   });
 
   it('focuses the owned session band after a successful blocked retry removes its trigger', async () => {

--- a/ui/src/components/sidebar/__tests__/threadApi.crewSession.test.ts
+++ b/ui/src/components/sidebar/__tests__/threadApi.crewSession.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { fetchCrewTaskDetail, fetchRoomSummaries, repairRoomSummaries } from '../threadApi';
+import { fetchCrewTaskDetail, fetchNotificationContext, fetchRoomSummaries, repairRoomSummaries } from '../threadApi';
 import type {
   CrewSessionDetailProjection,
   CrewSessionSummaryProjection,
@@ -147,6 +147,130 @@ function response(body: unknown, status = 200): Response {
 afterEach(() => {
   vi.unstubAllGlobals();
   vi.restoreAllMocks();
+});
+
+function notificationContext(state: CrewSessionDetailProjection['state'] = 'done') {
+  const completed = detail();
+  const session: CrewSessionDetailProjection = state === 'done' ? completed : {
+    ...completed, state, result: null, verification: null,
+    timestamps: {
+      ...completed.timestamps, verified_at: null,
+      completed_at: state === 'failed' ? 3 : null,
+      started_at: state === 'discussing' ? null : 2,
+      first_result_at: state === 'verifying' ? 2.5 : null,
+    },
+    progress: { total: 1, done: 0, failed: state === 'failed' ? 1 : 0, active: state === 'executing' ? 1 : 0, active_child: null },
+    blocker: state === 'blocked_needs_captain'
+      ? { reason: 'Approval needed', since: 3, duration_seconds: 0, action: 'retry_start_work' }
+      : null,
+  };
+  return {
+    kind: 'crew_session', notification_id: SHA_A, delivery_revision: 1,
+    thread: {
+      id: 'thread-1', task_id: 'parent-1', title: 'Room', participants: ['facilitator-1'],
+      project_id: null, pinned: false, archived: false, personality_override: null,
+      workspace_root: null, created_at: 1, last_active_at: 3, preprompt: null,
+      model: null, metadata: {},
+    },
+    session,
+  };
+}
+
+describe('notification context transport', () => {
+  it('accepts current correlated context and restricts the request to same origin without redirects', async () => {
+    const context = notificationContext();
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response(context)));
+    expect(await fetchNotificationContext(SHA_A)).toEqual({ kind: 'success', context });
+    expect(fetch).toHaveBeenCalledWith(`/api/notifications/${SHA_A}/context`, {
+      method: 'GET', mode: 'same-origin', redirect: 'error', cache: 'no-store', headers: {}, signal: undefined,
+    });
+  });
+
+  it('accepts completed context at the exact delivery revision', async () => {
+    const context = notificationContext();
+    context.delivery_revision = context.session.revision;
+    expect(context.session.state).toBe('done');
+    vi.stubGlobal('fetch', vi.fn()
+      .mockResolvedValueOnce(response({ session: context.session }))
+      .mockResolvedValueOnce(response(context)));
+    expect(await fetchCrewTaskDetail(context.session.task_id)).toEqual({
+      kind: 'success', response: { session: context.session },
+    });
+    expect(await fetchNotificationContext(SHA_A)).toEqual({ kind: 'success', context });
+    expect(fetch).toHaveBeenLastCalledWith(`/api/notifications/${SHA_A}/context`, expect.objectContaining({
+      method: 'GET', mode: 'same-origin', redirect: 'error',
+    }));
+  });
+
+  for (const state of ['done', 'failed', 'blocked_needs_captain', 'discussing', 'executing', 'verifying'] as const) {
+    it.each(['equal', 'stale', 'newer'] as const)(`validates ${state} context at %s revision without rejecting its detail shape`, async relation => {
+      const context = notificationContext(state);
+      context.delivery_revision = relation === 'stale' ? 3 : relation === 'equal' ? 2 : 1;
+      expect(context.session.revision).toBe(2);
+      expect(context.delivery_revision).toBe(relation === 'stale' ? 3 : relation === 'equal' ? 2 : 1);
+      vi.stubGlobal('fetch', vi.fn()
+        .mockResolvedValueOnce(response({ session: context.session }))
+        .mockResolvedValueOnce(response(context)));
+      expect(await fetchCrewTaskDetail(context.session.task_id)).toEqual({
+        kind: 'success', response: { session: context.session },
+      });
+      const deliverable = ['done', 'failed', 'blocked_needs_captain'].includes(state);
+      const accepted = relation === 'newer' || (relation === 'equal' && deliverable);
+      expect(await fetchNotificationContext(SHA_A)).toEqual(accepted
+        ? { kind: 'success', context }
+        : { kind: 'error', status: 200 });
+      expect(fetch).toHaveBeenCalledTimes(2);
+    });
+  }
+
+  it('forwards the page token only on context reads', async () => {
+    const previous = window.location.href;
+    window.history.replaceState(null, '', '?token=secret%20value');
+    try {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response(notificationContext())));
+      await fetchNotificationContext(SHA_A);
+      await fetchCrewTaskDetail('parent-1');
+      expect(fetch).toHaveBeenNthCalledWith(1, `/api/notifications/${SHA_A}/context`, expect.objectContaining({
+        headers: { Authorization: 'Bearer secret value' },
+      }));
+      expect(fetch).toHaveBeenNthCalledWith(2, '/api/crew-tasks/parent-1');
+    } finally {
+      window.history.replaceState(null, '', previous);
+    }
+  });
+
+  it.each(['', 'n1', 'A'.repeat(64), 'https://example.com', '../accept'])('rejects invalid ID %s without fetching', async id => {
+    vi.stubGlobal('fetch', vi.fn());
+    expect(await fetchNotificationContext(id)).toEqual({ kind: 'error', status: 422 });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { action_url: 'https://example.com' }, { command: 'retry_start_work' },
+    { notification_id: SHA_B }, { delivery_revision: 3 }, { delivery_revision: -1 },
+    { session: { ...detail(), thread_id: 'other' } },
+    { session: { ...detail(), task_id: 'other' } },
+    { delivery_revision: 2, session: { ...detail(), revision: 1 } },
+    { session: { ...detail(), extra: true } },
+    { thread: { ...notificationContext().thread, archived: true } },
+    { thread: { ...notificationContext().thread, task_id: null } },
+    { thread: { ...notificationContext().thread, participants: [''] } },
+  ])('rejects malformed or uncorrelated context %j', async override => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response({ ...notificationContext(), ...override })));
+    expect(await fetchNotificationContext(SHA_A)).toEqual({ kind: 'error', status: 200 });
+  });
+
+  it.each([401, 404, 409, 410, 503])('preserves unavailable status %s', async status => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response({}, status)));
+    expect(await fetchNotificationContext(SHA_A)).toEqual({ kind: 'error', status });
+  });
+
+  it('reports network failure and rejects redirected success', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValueOnce(new Error('offline'))
+      .mockResolvedValueOnce({ ...response(notificationContext()), redirected: true }));
+    expect(await fetchNotificationContext(SHA_A)).toEqual({ kind: 'error', status: null });
+    expect(await fetchNotificationContext(SHA_A)).toEqual({ kind: 'error', status: 200 });
+  });
 });
 
 describe('AD-1132 threadApi CrewSession contracts', () => {

--- a/ui/src/components/sidebar/threadApi.ts
+++ b/ui/src/components/sidebar/threadApi.ts
@@ -39,6 +39,80 @@ export interface ListThreadsOptions {
   limit?: number;
 }
 
+export interface NotificationContext {
+  kind: 'crew_session';
+  notification_id: string;
+  delivery_revision: number;
+  thread: AD791aChatThreadView;
+  session: CrewSessionDetailProjection;
+}
+
+export type NotificationContextOutcome =
+  | { kind: 'success'; context: NotificationContext }
+  | { kind: 'error'; status: number | null };
+
+function isContextIdentifier(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0 && value.length <= 256
+    && value.trim() === value && !/[\u0000-\u001f\u007f]/.test(value);
+}
+
+function isNotificationContext(value: unknown, notificationId: string): value is NotificationContext {
+  if (!isRecord(value) || !hasExactKeys(value, [
+    'kind', 'notification_id', 'delivery_revision', 'thread', 'session',
+  ]) || value.kind !== 'crew_session' || value.notification_id !== notificationId
+    || !Number.isSafeInteger(value.delivery_revision) || (value.delivery_revision as number) < 0
+    || !isCrewSessionDetailProjection(value.session)) return false;
+  const { thread, session } = value;
+  if (!isRecord(thread) || !hasExactKeys(thread, [
+    'id', 'title', 'participants', 'project_id', 'task_id', 'pinned', 'archived',
+    'personality_override', 'workspace_root', 'created_at', 'last_active_at',
+    'preprompt', 'model', 'metadata',
+  ])) return false;
+  return isContextIdentifier(thread.id)
+    && isContextIdentifier(thread.task_id)
+    && typeof thread.title === 'string'
+    && isStringArray(thread.participants)
+    && thread.participants.every(isContextIdentifier)
+    && new Set(thread.participants).size === thread.participants.length
+    && isNullableString(thread.project_id)
+    && typeof thread.pinned === 'boolean' && thread.archived === false
+    && isNullableString(thread.personality_override)
+    && isNullableString(thread.workspace_root)
+    && isNullableString(thread.preprompt) && isNullableString(thread.model)
+    && isRecord(thread.metadata)
+    && isFiniteNumber(thread.created_at) && isFiniteNumber(thread.last_active_at)
+    && thread.id === session.thread_id && thread.task_id === session.task_id
+    && isContextIdentifier(session.originator_id)
+    && isContextIdentifier(session.facilitator_id)
+    && session.owner_ids.every(isContextIdentifier)
+    && Number.isSafeInteger(session.revision)
+    && session.revision >= (value.delivery_revision as number)
+    && (session.revision > (value.delivery_revision as number)
+      || session.state === 'done' || session.state === 'failed' || session.state === 'blocked_needs_captain');
+}
+
+export async function fetchNotificationContext(
+  notificationId: string, signal?: AbortSignal,
+): Promise<NotificationContextOutcome> {
+  if (typeof notificationId !== 'string' || !/^[0-9a-f]{64}$/.test(notificationId)) {
+    return { kind: 'error', status: 422 };
+  }
+  try {
+    const token = new URLSearchParams(window.location.search).get('token');
+    const response = await fetch(`/api/notifications/${encodeURIComponent(notificationId)}/context`, {
+      method: 'GET', mode: 'same-origin', redirect: 'error', cache: 'no-store',
+      headers: token ? { Authorization: `Bearer ${token}` } : {}, signal,
+    });
+    if (!response.ok || response.redirected) return { kind: 'error', status: response.status };
+    const context: unknown = await response.json();
+    return isNotificationContext(context, notificationId)
+      ? { kind: 'success', context }
+      : { kind: 'error', status: response.status };
+  } catch {
+    return { kind: 'error', status: null };
+  }
+}
+
 export async function listThreads(opts: ListThreadsOptions = {}): Promise<AD791aChatThreadView[]> {
   const includeArchived = opts.includeArchived ?? false;
   const limit = opts.limit ?? 100;

--- a/ui/src/store/types.ts
+++ b/ui/src/store/types.ts
@@ -380,7 +380,7 @@ export interface NotificationView {
     intent?: string;
     params?: Record<string, unknown>;
     target_agent_id?: string;
-  };
+  } | null;
   created_at: number;
   acknowledged: boolean;
 }

--- a/ui/src/store/useStore.ts
+++ b/ui/src/store/useStore.ts
@@ -311,6 +311,24 @@ export function approvalKey(queue: PendingApproval['queue'], id: string): string
   return `${queue}${APPROVAL_KEY_SEP}${id}`;
 }
 
+export interface ComposerDraft {
+  text: string;
+  attachments: import('./types').ChatAttachment[];
+  pendingUploads: number;
+  error: string | null;
+}
+
+export interface NotificationNavigation {
+  requestId: symbol;
+  generation: string | null;
+  destination: {
+    hostId: string;
+    threadId: string;
+    parentId: string;
+    updated: boolean;
+  } | null;
+}
+
 export interface HXIState {
   // Data
   agents: Map<string, Agent>;
@@ -380,6 +398,8 @@ export interface HXIState {
   // binding. ``openAgentProfile`` (a roster/1:1 open) clears it back to null,
   // re-resolving the profile to the agent's 1:1 default.
   activeProfileThreadId: string | null;
+  notificationNavigation: NotificationNavigation | null;
+  setNotificationNavigation: (request: NotificationNavigation | null) => void;
   profilePanelPos: { x: number; y: number };
   // AD-940: the floating CHATS panel's drag position (GamePanel / profilePanelPos
   // pattern). Init matches its prior fixed on-screen origin so nothing jumps.
@@ -523,6 +543,8 @@ export interface HXIState {
   // (and any future "insert text" affordance) write here; ProfileChatTab
   // consumes the value, hydrates its local input state, and clears it.
   chatDrafts: Record<string, string>;
+  composerDrafts: ReadonlyMap<string, ComposerDraft>;
+  updateComposerDraft: (owner: string, update: (draft: ComposerDraft) => ComposerDraft) => void;
 
   // Audio state
   soundEnabled: boolean;
@@ -1337,6 +1359,8 @@ export const useStore = create<HXIState>((set, get) => ({
   activeProfileAgent: null,
   // AD-937: no group override at boot; set only by openGroupChatThread.
   activeProfileThreadId: null,
+  notificationNavigation: null,
+  setNotificationNavigation: (request) => set({ notificationNavigation: request }),
   profilePanelPos: { x: 100, y: 100 },
   // AD-940: match the CHATS panel's prior fixed origin (left:60 / top:60) so
   // enabling drag does not visually move it on first render.
@@ -1461,6 +1485,18 @@ export const useStore = create<HXIState>((set, get) => ({
   pendingRequests: 0,
   pendingChar: '',
   chatDrafts: {},
+  composerDrafts: new Map(),
+  updateComposerDraft: (owner, update) => {
+    if (!owner) return;
+    set((state) => {
+      const drafts = new Map(state.composerDrafts);
+      const current = drafts.get(owner) ?? {
+        text: '', attachments: [], pendingUploads: 0, error: null,
+      };
+      drafts.set(owner, update(current));
+      return { composerDrafts: drafts };
+    });
+  },
   soundEnabled: false,
   voiceEnabled: false,
   // AD-949: call audio ON by default — combined with the hook's meetingActive
@@ -1533,6 +1569,7 @@ export const useStore = create<HXIState>((set, get) => ({
   },
   // Agent Profile Panel actions (AD-406)
   openAgentProfile: (agentId) => set({
+    notificationNavigation: null,
     activeProfileAgent: agentId,
     // AD-937: a roster/1:1 open clears any group override so the profile
     // re-resolves to the agent's 1:1 default (the unreachable-1:1 fix).
@@ -1543,6 +1580,7 @@ export const useStore = create<HXIState>((set, get) => ({
   // group is addressable WITHOUT clobbering the host's single ``threadIdByAgent``
   // 1:1 slot. Mirrors openAgentProfile's body otherwise (dismiss tooltip).
   openGroupChatThread: (hostId, threadId) => set({
+    notificationNavigation: null,
     activeProfileAgent: hostId,
     activeProfileThreadId: threadId,
     pinnedAgent: null,
@@ -1552,7 +1590,7 @@ export const useStore = create<HXIState>((set, get) => ({
   // participants, so nulling only activeProfileAgent leaves an agent-created
   // group chat open (the close ✕ appears to do nothing). A 1:1 keyed on
   // activeProfileAgent is unaffected (its threadId override is already null).
-  closeAgentProfile: () => set({ activeProfileAgent: null, activeProfileThreadId: null }),
+  closeAgentProfile: () => set({ activeProfileAgent: null, activeProfileThreadId: null, notificationNavigation: null }),
   // AD-513: Crew Manifest actions
   openCrewManifest: async () => {
     set({ crewManifestOpen: true });
@@ -1837,7 +1875,7 @@ export const useStore = create<HXIState>((set, get) => ({
     // Clear the group-thread override too (AD-954a): the group surface renders
     // from activeProfileThreadId, so it must be nulled to actually minimize a
     // group chat (same root cause as the closeAgentProfile fix).
-    set({ activeProfileAgent: null, activeProfileThreadId: null, agentConversations: convs });
+    set({ activeProfileAgent: null, activeProfileThreadId: null, agentConversations: convs, notificationNavigation: null });
   },
   addAgentMessage: (agentId, role, text, opts) => {
     const convs = new Map(get().agentConversations);


### PR DESCRIPTION
## Summary
- Resolve CrewSession notification context from durable, server-owned provenance and open the exact existing room and current diagnostic/result through public navigation.
- Preserve room-owned drafts and attachment references, keep acknowledgement/Accept/recovery separate, and retain unresolved rooms through notification pruning and reconnects.
- Keep the opened profile and Bridge controls pointer-accessible, including profile close while Bridge remains open, and accept completed deliveries at their exact delivery revision.

Fixes #1373

## Validation
- Canonical full gate on commit 62e29e89b428890e2debbd02534c095d185c2d80, tree b7659fc8ae9ffe3e97117dfd123f65e1012df2ba: 30,008 passed, 30 skipped, 7 subtests passed.
- Focused delivery/API: 132 passed; endpoint boundaries: 18 passed; UI consumers: 211 passed; layout/approval route: 47 passed; additional exact F2 checks passed.
- Production TypeScript/Vite build passed; all 7 Chromium workflows and the exact 900px pointer selector passed with screenshots at 900px and 1440px.
- Two independently reported High defects were reproduced and repaired before commit. Fresh pre-commit review and the mapped Claude Opus 5 formal review passed with host-verified different-family separation.
- Canonical receipt SHA-256: 2f70497fd395b01dc60b6a17ed283bbcf0545e67111f59d8d1c2fc8ae37e85b2. Formal handoff chain verified in committed mode before push.

## Scope And Residuals
No production ProbOS process or production data was used. The original checked Python-to-browser fixture is preserved. General host navigation, inline approvals, and fault surfacing remain with their existing issues. Broader panel stacking combinations and host-specific compact/mobile draft mounts remain residual coverage limits; no unresolved Critical or High finding was accepted.
