### PR TITLE
fix(hxi): reconcile group replies by persisted identity

### DIFF
--- a/src/probos/routers/thread_fanout.py
+++ b/src/probos/routers/thread_fanout.py
@@ -443,7 +443,7 @@ async def _fan_one_round(
     broadcast: bool = False,
     max_speakers_override: int | None = None,
     _semantic_replies: list[dict[str, str]] | None = None,
-) -> list[dict[str, str]]:
+) -> list[dict[str, Any]]:
     """One reactivity round (AD-935): facilitate over ``candidate_ids`` (minus
     ``exclude_ids``) using ``trigger_body`` for mention/relevance, dispatch the
     chosen speakers in parallel, persist each non-[NO_RESPONSE] reply, write
@@ -534,7 +534,7 @@ async def _fan_one_round(
     write_ledgers: dict[str, WriteLedger] = {}
     semantic_texts: list[str] = [""] * len(speaking_order)
 
-    async def _send_one(reply_index: int, agent_id: str) -> dict[str, str]:
+    async def _send_one(reply_index: int, agent_id: str) -> dict[str, Any]:
         callsign = ""
         agent: Any = None
         try:
@@ -771,6 +771,7 @@ async def _fan_one_round(
             return {"agent_id": agent_id, "callsign": callsign, "text": "", "_declined": True}
         if _semantic_replies is not None:
             semantic_texts[reply_index] = project_convergence_body(reply_text, convergence_evidence)
+        persisted_message: dict[str, Any] | None = None
         try:
             # AD-933b: attach the generated-image refs only when the
             # escalation produced any; an empty/failed escalation leaves the
@@ -778,17 +779,29 @@ async def _fan_one_round(
             metadata: dict[str, Any] = {"intent_id": intent.id, "fanout": "ad914"}
             if generated_ids:
                 metadata["generated_attachment_ids"] = generated_ids
-            store.append_message(
+            saved_message = store.append_message(
                 thread_id, author_id=agent_id, role="agent",
                 body=reply_text, metadata=metadata,
                 convergence_evidence=convergence_evidence,
             )
+            if saved_message is not None:
+                persisted_message = saved_message.to_dict()
+            else:
+                logger.warning(
+                    "Group reply was not persisted for thread=%s agent=%s; "
+                    "returning transient text without a canonical message receipt",
+                    thread_id, agent_id,
+                )
         except Exception:
             logger.warning(
-                "AD-914: persist reply failed for thread=%s agent=%s",
+                "Group reply persistence failed for thread=%s agent=%s; "
+                "returning transient text without a canonical message receipt",
                 thread_id, agent_id, exc_info=True,
             )
-        return {"agent_id": agent_id, "callsign": callsign, "text": reply_text}
+        return {
+            "agent_id": agent_id, "callsign": callsign, "text": reply_text,
+            "message": persisted_message,
+        }
 
     # AD-978: freshen every observer agent's visual working memory ONCE before
     # the parallel dispatch (shared camera frame -> one describe, not one per
@@ -930,7 +943,7 @@ async def _fan_one_round(
 def _record_conversation_trust(
     runtime: Any,
     thread: Any,
-    all_replies: list[dict[str, str]],
+    all_replies: list[dict[str, Any]],
     agent_ids: list[str],
 ) -> None:
     """AD-958 (epic #882, #894): credit a CONVERGENT conversation as bounded
@@ -993,7 +1006,7 @@ def _record_conversation_trust(
 def _observe_conversation_corrections(
     runtime: Any,
     thread: Any,
-    all_replies: list[dict[str, str]],
+    all_replies: list[dict[str, Any]],
     agent_ids: list[str],
 ) -> None:
     """AD-958c (#882, #894): DETECT-AND-OBSERVE peer-corrects-peer signals.
@@ -1275,7 +1288,7 @@ async def group_chat_fanout(
     captain_body: str,
     captain_msg: Any,
     opener_id: str | None = None,
-) -> list[dict[str, str]]:
+) -> list[dict[str, Any]]:
     """Fan the Captain turn out to all crew-agent participants, then (when
     ``group_chat.agent_reactivity_enabled`` is True) run a BOUNDED SYNCHRONOUS
     agent-to-agent cascade for up to ``max_agent_rounds`` extra rounds (AD-935).
@@ -1347,7 +1360,7 @@ async def group_chat_fanout(
     # just-appended Captain message out of each agent's history (byte-identical).
     # AD-970: an agent-initiated kickoff passes opener_id so the opener is
     # excluded from round 0 (it just spoke); a Captain turn excludes nobody.
-    all_replies: list[dict[str, str]] = []
+    all_replies: list[dict[str, Any]] = []
     semantic_replies: list[dict[str, str]] = []
     # AD-963b: hoist the turn-mode policy ABOVE round 0 so the department-dominant
     # weight tilt reaches round 0 — the round that decides who FRAMES the topic

--- a/tests/test_ad1293_turn_record_reaches_episode.py
+++ b/tests/test_ad1293_turn_record_reaches_episode.py
@@ -273,7 +273,21 @@ async def _exercise_group_notebook_recall(
         ]
         assert len(messages) == len(replies) == 2
         assert sorted(message.author_id for message in messages) == ["counselor1", "scout1"]
-        assert all(set(reply) == {"agent_id", "callsign", "text"} for reply in replies)
+        assert all(set(reply) == {"agent_id", "callsign", "text", "message"} for reply in replies)
+        for reply in replies:
+            receipt = reply["message"]
+            assert receipt is not None
+            matching = [message for message in messages if message.id == receipt["id"]]
+            assert len(matching) == 1
+            stored = matching[0]
+            assert receipt == stored.to_dict()
+            assert receipt["thread_id"] == stored.thread_id == thread.id
+            assert receipt["author_id"] == stored.author_id == reply["agent_id"]
+            assert receipt["role"] == stored.role == "agent"
+            assert receipt["body"] == stored.body == reply["text"]
+            assert receipt["created_at"] == stored.created_at
+            assert receipt["metadata"] == stored.metadata
+        assert len({reply["message"]["id"] for reply in replies}) == len(replies)
         rows = _agent_rows(store, thread.id)
         assert rows == {reply["agent_id"]: reply["text"] for reply in replies}
         expected_composition_inputs = list(rows.values())

--- a/tests/test_ad914_group_chat_fanout.py
+++ b/tests/test_ad914_group_chat_fanout.py
@@ -10,8 +10,13 @@ real ``threads`` router with a ``SimpleNamespace`` runtime via
 """
 from __future__ import annotations
 
+import json
+from functools import partial
+from pathlib import Path
 from types import SimpleNamespace
+from typing import Any
 
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -62,9 +67,10 @@ def _seq_clock():
     return _c
 
 
-def _make_recording_handler(received: dict, agent_id: str):
+def _make_recording_handler(received: dict, agent_id: str, reply_text: str | None = None):
     async def _h(intent: IntentMessage) -> IntentResult:
         received[agent_id] = {
+            "call_count": received.get(agent_id, {}).get("call_count", 0) + 1,
             "text": intent.params.get("text"),
             "history": intent.params.get("session_history"),
             "session": intent.params.get("session"),
@@ -75,7 +81,7 @@ def _make_recording_handler(received: dict, agent_id: str):
             intent_id=intent.id,
             agent_id=agent_id,
             success=True,
-            result=f"reply::{agent_id}",
+            result=f"reply::{agent_id}" if reply_text is None else reply_text,
         )
 
     return _h
@@ -88,14 +94,18 @@ def _make_raising_handler(agent_id: str):
     return _h
 
 
-def _build_env(tmp_path, *, agents, callsigns=None, subscribe=None, raising=None):
+def _build_env(
+    tmp_path, *, agents, callsigns=None, subscribe=None, raising=None,
+    reply_texts=None, store=None,
+):
     """agents: {agent_id: agent_type}. callsigns: {agent_type: callsign}.
 
     subscribe: agent_ids that get a recording handler (default: all).
     raising: agent_ids whose handler raises (delivery-failed path).
     Returns (store, runtime, received).
     """
-    store = ChatThreadStore(tmp_path / "threads.db", clock=_seq_clock())
+    if store is None:
+        store = ChatThreadStore(tmp_path / "threads.db", clock=_seq_clock())
     bus = IntentBus(SignalManager(reap_interval=1.0))
     registry = _FakeRegistry({aid: _FakeAgent(at) for aid, at in agents.items()})
     runtime = SimpleNamespace(
@@ -110,7 +120,10 @@ def _build_env(tmp_path, *, agents, callsigns=None, subscribe=None, raising=None
     sub_ids = list(agents.keys()) if subscribe is None else list(subscribe)
     raise_ids = set(raising or ())
     for aid in sub_ids:
-        handler = _make_raising_handler(aid) if aid in raise_ids else _make_recording_handler(received, aid)
+        handler = (
+            _make_raising_handler(aid) if aid in raise_ids
+            else _make_recording_handler(received, aid, (reply_texts or {}).get(aid))
+        )
         bus.subscribe(aid, handler, intent_names=["direct_message"])
     return store, runtime, received
 
@@ -341,18 +354,259 @@ async def test_fanout_response_includes_per_agent_replies(tmp_path):
         callsigns={"scout": "Scout", "counselor": "Troi"},
     )
     t = store.create_thread(title="room", participants=["scout1", "counselor1"])
+    assert isinstance(runtime.intent_bus, IntentBus)
+    assert sorted(crew_agent_participants(runtime, t.participants)) == [
+        "counselor1", "scout1",
+    ]
+    assert store.list_messages(t.id, limit=1000) == []
     client = _rest_client(runtime)
     r = client.post(
         f"/api/threads/{t.id}/messages",
         json={"author_id": "captain", "role": "captain", "body": "all hands"},
     )
     assert r.status_code == 200
+    assert set(received.keys()) == {"scout1", "counselor1"}
+    for agent_id in ("scout1", "counselor1"):
+        assert received[agent_id]["call_count"] == 1
+        assert received[agent_id]["text"] == "all hands"
+        assert received[agent_id]["from"] == "hxi_profile"
+        assert received[agent_id]["thread_id"] == t.id
+
+    persisted = store.list_messages(t.id, limit=1000)
+    assert len(persisted) == 3
+    assert len({message.id for message in persisted}) == 3
+    captain_rows = [message for message in persisted if message.role == "captain"]
+    agent_rows = [message for message in persisted if message.role == "agent"]
+    assert len(captain_rows) == 1
+    assert captain_rows[0].author_id == "captain"
+    assert captain_rows[0].body == "all hands"
+    assert len(agent_rows) == 2
+    assert {message.author_id for message in agent_rows} == {"scout1", "counselor1"}
+    for message in agent_rows:
+        assert message.body == f"reply::{message.author_id}"
+        assert message.metadata["fanout"] == "ad914"
+        assert message.metadata["intent_id"]
+
     body = r.json()
     assert "per_agent_replies" in body
+    assert {
+        key: value for key, value in body.items() if key != "per_agent_replies"
+    } == captain_rows[0].to_dict()
     replies = body["per_agent_replies"]
+    assert len(replies) == 2
     assert {x["agent_id"] for x in replies} == {"scout1", "counselor1"}
     assert {x["text"] for x in replies} == {"reply::scout1", "reply::counselor1"}
-    assert set(received.keys()) == {"scout1", "counselor1"}
+    persisted_by_author = {message.author_id: message for message in agent_rows}
+    for reply in replies:
+        assert reply["message"] == persisted_by_author[reply["agent_id"]].to_dict()
+
+
+@pytest.mark.parametrize(
+    "case", ["plain", "normalized", "same_text", "none", "raise", "empty", "declined"],
+)
+def test_fanout_receipt_boundaries_preserve_successful_peer(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture, case: str,
+) -> None:
+    from probos.cognitive.dm.bypass_egress import UNRENDERABLE_NOTE
+
+    reply_texts = {
+        "scout1": "reply::scout1",
+        "counselor1": "reply::counselor1",
+    }
+    if case == "normalized":
+        reply_texts["scout1"] = "Status [A2UI]{}[/A2UI]"
+    elif case == "same_text":
+        reply_texts = dict.fromkeys(reply_texts, "Ready for the next task.")
+    elif case in {"empty", "declined"}:
+        reply_texts["scout1"] = "" if case == "empty" else "[NO_RESPONSE]"
+    store, runtime, received = _build_env(
+        tmp_path,
+        agents={"scout1": "scout", "counselor1": "counselor"},
+        callsigns={"scout": "Scout", "counselor": "Troi"},
+        reply_texts=reply_texts,
+    )
+    thread = store.create_thread(title="room", participants=["scout1", "counselor1"])
+    assert isinstance(runtime.intent_bus, IntentBus)
+    assert set(crew_agent_participants(runtime, thread.participants)) == set(reply_texts)
+    assert store.list_messages(thread.id, limit=1000) == []
+    committed = []
+    store.set_message_committed_callback(committed.append)
+    append_message = store.append_message
+    attempted: list[str] = []
+
+    def append_with_failure(thread_id: str, **kwargs: Any) -> Any:
+        attempted.append(kwargs["author_id"])
+        if kwargs["author_id"] == "scout1" and case in {"none", "raise"}:
+            if case == "raise":
+                raise RuntimeError("injected persistence failure")
+            return None
+        return append_message(thread_id, **kwargs)
+
+    monkeypatch.setattr(store, "append_message", append_with_failure)
+    send_count = 2 if case == "same_text" else 1
+    responses: list[dict[str, Any]] = []
+    with _rest_client(runtime) as client:
+        for send_index in range(send_count):
+            response = client.post(
+                f"/api/threads/{thread.id}/messages",
+                json={
+                    "author_id": "captain", "role": "captain", "body": "all hands",
+                    "metadata": {"client_message_id": f"send-{send_index}"},
+                },
+            )
+            assert response.status_code == 200
+            responses.append(response.json())
+        history = client.get(f"/api/threads/{thread.id}/messages")
+        assert history.status_code == 200
+
+    assert set(received) == set(reply_texts)
+    assert {agent_id: entry["call_count"] for agent_id, entry in received.items()} == {
+        "scout1": send_count, "counselor1": send_count,
+    }
+    persisted = store.list_messages(thread.id, limit=1000)
+    expected_agents = {"counselor1"} if case in {"none", "raise", "empty", "declined"} else set(reply_texts)
+    assert len(persisted) == send_count * (1 + len(expected_agents))
+    assert len({row.id for row in persisted}) == len(persisted)
+    assert len([row for row in persisted if row.role == "captain"]) == send_count
+    assert {row.author_id for row in persisted if row.role == "agent"} == expected_agents
+    assert [row.to_dict() for row in committed] == [row.to_dict() for row in persisted]
+    assert history.json() == {
+        "thread_id": thread.id, "messages": [row.to_dict() for row in persisted],
+    }
+    persisted_by_id = {row.id: row.to_dict() for row in persisted}
+    for body in responses:
+        assert {key: value for key, value in body.items() if key != "per_agent_replies"} == persisted_by_id[body["id"]]
+        replies = {reply["agent_id"]: reply for reply in body["per_agent_replies"]}
+        expected_replies = {"counselor1"} if case in {"empty", "declined"} else set(reply_texts)
+        assert set(replies) == expected_replies
+        for agent_id, reply in replies.items():
+            assert reply["callsign"] == {"scout1": "Scout", "counselor1": "Troi"}[agent_id]
+            if agent_id == "scout1" and case in {"none", "raise"}:
+                assert reply["message"] is None
+                assert reply["text"] == reply_texts[agent_id]
+                continue
+            receipt = reply["message"]
+            assert receipt == persisted_by_id[receipt["id"]]
+            assert receipt["author_id"] == agent_id
+            assert receipt["thread_id"] == thread.id
+            assert receipt["role"] == "agent"
+            if agent_id == "scout1" and case == "normalized":
+                assert reply["text"] != receipt["body"]
+                assert reply["text"] == reply_texts[agent_id]
+                assert receipt["body"] == f"Status {UNRENDERABLE_NOTE}"
+            else:
+                assert reply["text"] == receipt["body"] == reply_texts[agent_id]
+    assert attempted.count("captain") == send_count
+    assert attempted.count("counselor1") == send_count
+    assert attempted.count("scout1") == (0 if case in {"empty", "declined"} else send_count)
+    if case in {"none", "raise"}:
+        assert "returning transient text without a canonical message receipt" in caplog.text
+        assert reply_texts["scout1"] not in caplog.text
+    if case == "same_text":
+        for agent_id in reply_texts:
+            rows = [row for row in persisted if row.author_id == agent_id]
+            assert len(rows) == 2
+            assert rows[0].body == rows[1].body == reply_texts[agent_id]
+            assert rows[0].id != rows[1].id
+            assert rows[0].created_at < rows[1].created_at
+
+
+def test_group_reply_identity_fixture_matches_real_producers(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import probos.runtime as runtime_module
+    import probos.threads as threads_module
+    from probos.config import SystemConfig
+    from probos.routers import thread_fanout
+
+    message_ids = iter(["identity-room", "identity-captain", "identity-reply-1", "identity-reply-2"])
+    with monkeypatch.context() as constructor_patch:
+        constructor_patch.setattr(
+            threads_module, "ChatThreadStore",
+            partial(ChatThreadStore, clock=_seq_clock(), id_factory=lambda: next(message_ids)),
+        )
+        event_runtime = runtime_module.ProbOSRuntime(
+            config=SystemConfig(), data_dir=tmp_path,
+        )
+    monkeypatch.setattr(
+        runtime_module, "time",
+        SimpleNamespace(**{**vars(runtime_module.time), "time": lambda: 1000.0}),
+    )
+
+    def deterministic_intent(**kwargs: Any) -> IntentMessage:
+        return IntentMessage(id=f"identity-intent-{kwargs['target_agent_id']}", **kwargs)
+
+    monkeypatch.setattr(thread_fanout, "IntentMessage", deterministic_intent)
+    store, runtime, received = _build_env(
+        tmp_path,
+        agents={"scout1": "scout", "counselor1": "counselor"},
+        callsigns={"scout": "Scout", "counselor": "Troi"},
+        store=event_runtime.chat_thread_store,
+    )
+    events: list[dict[str, Any]] = []
+
+    def capture_committed_event(event: dict[str, Any]) -> None:
+        if event["type"] == "chat_thread_message_appended":
+            events.append(event)
+
+    event_runtime.add_event_listener(capture_committed_event)
+    thread = store.create_thread(title="Identity room", participants=["scout1", "counselor1"])
+    assert store is event_runtime.chat_thread_store
+    assert isinstance(store, ChatThreadStore)
+    assert isinstance(runtime.intent_bus, IntentBus)
+    assert sorted(crew_agent_participants(runtime, thread.participants)) == ["counselor1", "scout1"]
+    assert store.list_messages(thread.id, limit=1000) == []
+    assert events == []
+    request = {
+        "author_id": "captain", "role": "captain", "body": "all hands",
+        "metadata": {"client_message_id": "identity-send-1"},
+    }
+    with _rest_client(runtime) as client:
+        response = client.post(f"/api/threads/{thread.id}/messages", json=request)
+        assert response.status_code == 200
+        history = client.get(f"/api/threads/{thread.id}/messages")
+        assert history.status_code == 200
+
+    assert set(received) == {"scout1", "counselor1"}
+    for agent_id, entry in received.items():
+        assert entry["call_count"] == 1
+        assert entry["text"] == request["body"]
+        assert entry["from"] == "hxi_profile"
+        assert entry["thread_id"] == thread.id
+        assert runtime.registry.get(agent_id) is not None
+    rows = store.list_messages(thread.id, limit=1000)
+    assert len(rows) == 3
+    assert len({row.id for row in rows}) == 3
+    assert [row.author_id for row in rows if row.role == "captain"] == ["captain"]
+    assert {row.author_id for row in rows if row.role == "agent"} == set(received)
+    assert history.json() == {"thread_id": thread.id, "messages": [row.to_dict() for row in rows]}
+    body = response.json()
+    assert {key: value for key, value in body.items() if key != "per_agent_replies"} == rows[0].to_dict()
+    assert len(body["per_agent_replies"]) == 2
+    rows_by_author = {row.author_id: row for row in rows}
+    for reply in body["per_agent_replies"]:
+        assert reply["message"] == rows_by_author[reply["agent_id"]].to_dict()
+        assert reply["text"] == f"reply::{reply['agent_id']}"
+    assert len(events) == 3
+    for event, row in zip(events, rows):
+        assert event["data"] == {
+            "thread_id": row.thread_id, "message_id": row.id,
+            "author_id": row.author_id, "role": row.role, "created_at": row.created_at,
+        }
+        assert event["timestamp"] == 1000.0
+    actual = {
+        "thread": thread.to_dict(), "request": request,
+        "response": body, "history": history.json(), "events": events,
+    }
+    fixture_path = Path(__file__).resolve().parents[1] / "ui/e2e/fixtures/group-reply-identity.json"
+    if not fixture_path.is_file():
+        pytest.fail(
+            "Producer assertions passed; Worker must bank this actual fixture payload:\n"
+            + json.dumps(actual, indent=2, sort_keys=True),
+            pytrace=False,
+        )
+    assert json.loads(fixture_path.read_text(encoding="utf-8")) == actual
 
 
 async def test_messages_endpoint_unchanged_for_non_group(tmp_path):

--- a/tests/test_ad933_group_chat_escalation.py
+++ b/tests/test_ad933_group_chat_escalation.py
@@ -492,7 +492,21 @@ async def _run_disparate_disclosure_turn(
     assert {message.author_id for message in agent_messages} == set(agents)
     assert len({reply["agent_id"] for reply in replies}) == 4
     assert {reply["agent_id"] for reply in replies} == set(agents)
-    assert all(set(reply) == {"agent_id", "callsign", "text"} for reply in replies)
+    assert all(set(reply) == {"agent_id", "callsign", "text", "message"} for reply in replies)
+    for reply in replies:
+        receipt = reply["message"]
+        assert receipt is not None
+        matching = [message for message in agent_messages if message.id == receipt["id"]]
+        assert len(matching) == 1
+        stored = matching[0]
+        assert receipt == stored.to_dict()
+        assert receipt["thread_id"] == stored.thread_id == thread.id
+        assert receipt["author_id"] == stored.author_id == reply["agent_id"]
+        assert receipt["role"] == stored.role == "agent"
+        assert receipt["body"] == stored.body == reply["text"]
+        assert receipt["created_at"] == stored.created_at
+        assert receipt["metadata"] == stored.metadata
+    assert len({reply["message"]["id"] for reply in replies}) == len(replies)
     rows = {message.author_id: message.body for message in agent_messages}
     reply_bodies = {reply["agent_id"]: reply["text"] for reply in replies}
     assert reply_bodies == rows
@@ -668,10 +682,10 @@ async def test_disclosure_cascade_has_an_eligible_unspoken_candidate(
     runtime.config.group_chat.agent_next_speaker_selection_enabled = False
     runtime.config.group_chat.broadcast_terminator_enabled = False
     runtime.proactive_loop = producer
-    rounds: list[tuple[list[str], list[dict[str, str]]]] = []
+    rounds: list[tuple[list[str], list[dict[str, Any]]]] = []
     fan_round = thread_fanout._fan_one_round
 
-    async def record_round(*args: Any, **kwargs: Any) -> list[dict[str, str]]:
+    async def record_round(*args: Any, **kwargs: Any) -> list[dict[str, Any]]:
         pool = [agent_id for agent_id in kwargs["candidate_ids"] if agent_id not in kwargs["exclude_ids"]]
         result = await fan_round(*args, **kwargs)
         rounds.append((pool, result))
@@ -979,6 +993,21 @@ async def test_group_write_disclosure_does_not_decide_eligibility(
     }
     messages = [message for message in store.list_messages(thread.id, limit=1000) if message.role == "agent"]
     assert len(replies) == len(messages) == len(recorder.stored) == 1 + int(eligible)
+    for reply in replies:
+        assert set(reply) == {"agent_id", "callsign", "text", "message"}
+        receipt = reply["message"]
+        assert receipt is not None
+        matching = [message for message in messages if message.id == receipt["id"]]
+        assert len(matching) == 1
+        stored = matching[0]
+        assert receipt == stored.to_dict()
+        assert receipt["thread_id"] == stored.thread_id == thread.id
+        assert receipt["author_id"] == stored.author_id == reply["agent_id"]
+        assert receipt["role"] == stored.role == "agent"
+        assert receipt["body"] == stored.body == reply["text"]
+        assert receipt["created_at"] == stored.created_at
+        assert receipt["metadata"] == stored.metadata
+    assert len({reply["message"]["id"] for reply in replies}) == len(replies)
     peer_replies = [reply for reply in replies if reply["agent_id"] == "counselor1"]
     peer_messages = [message for message in messages if message.author_id == "counselor1"]
     peer_episodes = [episode for episode in recorder.stored if episode.agent_ids == ["counselor1"]]
@@ -999,7 +1028,7 @@ async def test_group_write_disclosure_does_not_decide_eligibility(
         assert writer_episodes[0].outcomes[0]["response"] == expected
         assert writer_episodes[0].self_contradicted_channels == ["notebook"]
         assert writer_episodes[0].outcomes[0]["success"] is True
-        assert set(writer_replies[0]) == {"agent_id", "callsign", "text"}
+        assert set(writer_replies[0]) == {"agent_id", "callsign", "text", "message"}
 
 
 @pytest.mark.parametrize("failure_stage", ["reply", "context", "pipeline", "before-producer"])
@@ -1071,7 +1100,11 @@ async def test_group_failure_before_write_facts_does_not_invent_ledger(
     replies = await group_chat_fanout(runtime, thread.id, captain_body=captain.body, captain_msg=captain)
 
     assert failures == [failure_stage]
-    assert semantic_replies == replies
+    assert semantic_replies == [
+        {"agent_id": reply["agent_id"], "callsign": reply["callsign"], "text": reply["text"]}
+        for reply in replies
+    ]
+    assert all(set(reply) == {"agent_id", "callsign", "text"} for reply in semantic_replies)
     assert all(semantic is not public for semantic, public in zip(semantic_replies, replies))
     assert producer.calls == []
     writer_contexts = [ctx for ctx in contexts if ctx.agent_id == "scout1"]
@@ -1080,6 +1113,21 @@ async def test_group_failure_before_write_facts_does_not_invent_ledger(
     assert all(ctx.pre_write_disclosure_body is None for ctx in writer_contexts)
     messages = [message for message in store.list_messages(thread.id, limit=1000) if message.role == "agent"]
     assert len(replies) == len(messages) == len(recorder.stored) == 2
+    for reply in replies:
+        assert set(reply) == {"agent_id", "callsign", "text", "message"}
+        receipt = reply["message"]
+        assert receipt is not None
+        matching = [message for message in messages if message.id == receipt["id"]]
+        assert len(matching) == 1
+        stored = matching[0]
+        assert receipt == stored.to_dict()
+        assert receipt["thread_id"] == stored.thread_id == thread.id
+        assert receipt["author_id"] == stored.author_id == reply["agent_id"]
+        assert receipt["role"] == stored.role == "agent"
+        assert receipt["body"] == stored.body == reply["text"]
+        assert receipt["created_at"] == stored.created_at
+        assert receipt["metadata"] == stored.metadata
+    assert len({reply["message"]["id"] for reply in replies}) == len(replies)
     for agent_id, expected in (("scout1", raw_fallback), ("counselor1", peer_text)):
         agent_replies = [reply for reply in replies if reply["agent_id"] == agent_id]
         agent_messages = [message for message in messages if message.author_id == agent_id]
@@ -1159,7 +1207,7 @@ async def test_round_semantic_accumulator_matches_non_disclosed_reply_order(
     monkeypatch.setattr(runtime.registry, "get", get_or_missing)
     seed = {"agent_id": "previous", "callsign": "Previous", "text": "Prior turn."}
     semantic = [seed]
-    all_replies: list[dict[str, str]] = []
+    all_replies: list[dict[str, Any]] = []
     round_count = 2 if case in {"ordinary", "disclosed"} else 1
     for _ in range(round_count):
         peer_completed.clear()
@@ -1181,7 +1229,7 @@ async def test_round_semantic_accumulator_matches_non_disclosed_reply_order(
         assert len(completed[-3:]) == 3 and set(completed[-3:]) == set(thread.participants)
         assert completed[-3:].index("voice2") < completed[-3:].index("voice1")
         for reply in replies:
-            assert set(reply) == {"agent_id", "callsign", "text"}
+            assert set(reply) == {"agent_id", "callsign", "text", "message"}
             expected_first = (
                 first_semantic + disclosure_for(ClaimVerdict.MARKER_WROTE_NOTHING)
                 if case == "disclosed" else first_text
@@ -1189,11 +1237,16 @@ async def test_round_semantic_accumulator_matches_non_disclosed_reply_order(
             assert reply["text"] == (expected_first if reply["agent_id"] == "voice1" else "Prefer velvet.")
         all_replies.extend(replies)
         expected_semantic = [
-            {**reply, "text": first_semantic}
-            if case == "disclosed" and reply["agent_id"] == "voice1" else dict(reply)
+            {
+                "agent_id": reply["agent_id"],
+                "callsign": reply["callsign"],
+                "text": first_semantic
+                if case == "disclosed" and reply["agent_id"] == "voice1" else reply["text"],
+            }
             for reply in all_replies
         ]
         assert semantic == [seed, *expected_semantic]
+        assert all(set(reply) == {"agent_id", "callsign", "text"} for reply in semantic)
         assert all(internal is not public for internal, public in zip(semantic[1:], all_replies))
         if case == "disclosed":
             assert any(internal["text"] != public["text"] for internal, public in zip(semantic[1:], all_replies))
@@ -1202,6 +1255,26 @@ async def test_round_semantic_accumulator_matches_non_disclosed_reply_order(
     assert len(messages) == len(all_replies) - int(case == "persist-failure")
     assert len(recorder.stored) == len(all_replies)
     assert persist_failures == ([first_text] if case == "persist-failure" else [])
+    receipt_ids: list[str] = []
+    for reply in all_replies:
+        receipt = reply["message"]
+        if case == "persist-failure" and reply["agent_id"] == "voice1":
+            assert receipt is None
+            assert not any(message.author_id == "voice1" for message in messages)
+        else:
+            assert receipt is not None
+            matching = [message for message in messages if message.id == receipt["id"]]
+            assert len(matching) == 1
+            stored = matching[0]
+            assert receipt == stored.to_dict()
+            assert receipt["thread_id"] == stored.thread_id == thread.id
+            assert receipt["author_id"] == stored.author_id == reply["agent_id"]
+            assert receipt["role"] == stored.role == "agent"
+            assert receipt["body"] == stored.body == reply["text"]
+            assert receipt["created_at"] == stored.created_at
+            assert receipt["metadata"] == stored.metadata
+            receipt_ids.append(receipt["id"])
+    assert len(receipt_ids) == len(set(receipt_ids)) == len(messages)
     assert all(
         ("ad1305_convergence" in message.metadata) is (case == "disclosed" and message.author_id == "voice1")
         for message in messages
@@ -1371,10 +1444,25 @@ async def test_fanout_return_shape_preserved_with_mutated_text(tmp_path):
             runtime, t.id, captain_body="handle it", captain_msg=cap
         )
 
-        # Shape {agent_id, callsign, text} preserved for every speaker.
+        # Public replies retain legacy fields and add the canonical receipt.
         assert len(replies) == 2
-        for r in replies:
-            assert set(r.keys()) == {"agent_id", "callsign", "text"}
+        messages = [message for message in store.list_messages(t.id) if message.role == "agent"]
+        assert len(messages) == 2
+        for reply in replies:
+            assert set(reply.keys()) == {"agent_id", "callsign", "text", "message"}
+            receipt = reply["message"]
+            assert receipt is not None
+            matching = [message for message in messages if message.id == receipt["id"]]
+            assert len(matching) == 1
+            stored = matching[0]
+            assert receipt == stored.to_dict()
+            assert receipt["thread_id"] == stored.thread_id == t.id
+            assert receipt["author_id"] == stored.author_id == reply["agent_id"]
+            assert receipt["role"] == stored.role == "agent"
+            assert receipt["body"] == stored.body == reply["text"]
+            assert receipt["created_at"] == stored.created_at
+            assert receipt["metadata"] == stored.metadata
+        assert len({reply["message"]["id"] for reply in replies}) == len(replies)
         by_id = {r["agent_id"]: r for r in replies}
         # The escalated reply's text is the MUTATED (tag-stripped + suffixed) text.
         assert "[CREATE_TASK" not in by_id["yeo1"]["text"]

--- a/tests/test_ad958_conversation_trust.py
+++ b/tests/test_ad958_conversation_trust.py
@@ -380,7 +380,22 @@ async def test_substantive_convergence_preserves_trust_and_mention_override(
     suffix = disclosure_for(ClaimVerdict.MARKER_WROTE_NOTHING) if writes and guard_enabled else ""
     expected_body = substantive + suffix
     assert {reply["agent_id"] for reply in replies} == set(agents)
-    assert all(set(reply) == {"agent_id", "callsign", "text"} for reply in replies)
+    assert all(set(reply) == {"agent_id", "callsign", "text", "message"} for reply in replies)
+    for reply in replies:
+        receipt = reply["message"]
+        assert receipt is not None
+        matching = [message for message in messages if message.id == receipt["id"]]
+        assert len(matching) == 1
+        stored = matching[0]
+        assert receipt == stored.to_dict()
+        assert receipt["thread_id"] == stored.thread_id == thread.id
+        assert receipt["author_id"] == stored.author_id == reply["agent_id"]
+        assert receipt["role"] == stored.role == "agent"
+        assert receipt["body"] == stored.body == reply["text"]
+        assert receipt["created_at"] == stored.created_at
+        assert receipt["metadata"] == stored.metadata
+    receipt_ids = {reply["message"]["id"] for reply in replies}
+    assert len(receipt_ids) == len(replies)
     assert all(reply["text"] == expected_body for reply in replies)
     for message in messages:
         assert message.body == expected_body
@@ -429,6 +444,24 @@ async def test_substantive_convergence_preserves_trust_and_mention_override(
     assert len(recorder.stored) == 6
     assert producer.calls == ([raw] * 6 if writes else [])
     assert len([message for message in store.list_messages(thread.id) if message.role == "agent"]) == 6
+    messages = [message for message in store.list_messages(thread.id) if message.role == "agent"]
+    for reply in mentioned_replies:
+        assert set(reply) == {"agent_id", "callsign", "text", "message"}
+        receipt = reply["message"]
+        assert receipt is not None
+        matching = [message for message in messages if message.id == receipt["id"]]
+        assert len(matching) == 1
+        stored = matching[0]
+        assert receipt == stored.to_dict()
+        assert receipt["thread_id"] == stored.thread_id == thread.id
+        assert receipt["author_id"] == stored.author_id == reply["agent_id"]
+        assert receipt["role"] == stored.role == "agent"
+        assert receipt["body"] == stored.body == reply["text"] == expected_body
+        assert receipt["created_at"] == stored.created_at
+        assert receipt["metadata"] == stored.metadata
+        assert receipt["id"] not in receipt_ids
+        receipt_ids.add(receipt["id"])
+    assert len(receipt_ids) == len(messages) == 6
     assert runtime.trust_network.get_recent_events() == events
 
 

--- a/tests/test_bf866_artifact_channel_seams.py
+++ b/tests/test_bf866_artifact_channel_seams.py
@@ -1005,7 +1005,22 @@ async def test_four_speaker_real_writes_preserve_semantic_trust_across_guard(
         assert sorted(failures) == (sorted(agents) if raw_fallback else [])
         assert len(semantic_replies) == 4
         assert [reply["agent_id"] for reply in semantic_replies] == [reply["agent_id"] for reply in replies]
-        assert all(set(reply) == {"agent_id", "callsign", "text"} for reply in replies)
+        assert all(set(reply) == {"agent_id", "callsign", "text"} for reply in semantic_replies)
+        assert all(set(reply) == {"agent_id", "callsign", "text", "message"} for reply in replies)
+        for reply in replies:
+            receipt = reply["message"]
+            assert receipt is not None
+            matching = [message for message in messages if message.id == receipt["id"]]
+            assert len(matching) == 1
+            stored = matching[0]
+            assert receipt == stored.to_dict()
+            assert receipt["thread_id"] == stored.thread_id == thread.id
+            assert receipt["author_id"] == stored.author_id == reply["agent_id"]
+            assert receipt["role"] == stored.role == "agent"
+            assert receipt["body"] == stored.body == reply["text"]
+            assert receipt["created_at"] == stored.created_at
+            assert receipt["metadata"] == stored.metadata
+        assert len({reply["message"]["id"] for reply in replies}) == len(replies)
         rows = {message.author_id: message for message in messages}
         by_context = {context.agent_id: context for context in contexts}
         assert {reply["agent_id"]: reply["text"] for reply in replies} == {
@@ -1085,6 +1100,7 @@ async def test_four_speaker_real_writes_preserve_semantic_trust_across_guard(
             {"agent_id": reply["agent_id"], "callsign": reply["callsign"], "text": expected_semantics[reply["agent_id"]]}
             for reply in replies
         ]
+        assert semantic_replies == control_replies
         outcomes = extract_conversation_trust_outcomes(
             control_replies, facilitator=facilitator, intent_type="write outcomes",
             positive_weight=0.05, max_outcomes=4,
@@ -1238,6 +1254,7 @@ async def test_group_real_write_outcomes_reach_durable_effects_and_episode(
             ClaimVerdict.MARKER_WROTE_PARTIALLY if expected_partial else ClaimVerdict.ABSTAIN
         )
         before_bytes: bytes | None = None
+        receipt_ids: set[str] = set()
         for turn in range(2 if notebook == "dedup" else 1):
             captain = store.append_message(
                 thread.id, author_id="captain", role="captain", body="Save the maintenance decision.",
@@ -1246,7 +1263,7 @@ async def test_group_real_write_outcomes_reach_durable_effects_and_episode(
                 runtime, thread.id, captain_body=captain.body, captain_msg=captain,
             )
             assert len(replies) == 2
-            assert all(set(reply) == {"agent_id", "callsign", "text"} for reply in replies)
+            assert all(set(reply) == {"agent_id", "callsign", "text", "message"} for reply in replies)
             rows = _agent_rows(store, thread.id)
             assert rows == {reply["agent_id"]: reply["text"] for reply in replies}
             assert rows["counselor1"] == peer_text
@@ -1311,6 +1328,22 @@ async def test_group_real_write_outcomes_reach_durable_effects_and_episode(
             messages = [message for message in store.list_messages(thread.id, limit=1000) if message.role == "agent"]
             episodes = await memory.list_episodes()
             assert len(messages) == len(episodes) == 2 * (turn + 1)
+            for reply in replies:
+                receipt = reply["message"]
+                assert receipt is not None
+                matching = [message for message in messages if message.id == receipt["id"]]
+                assert len(matching) == 1
+                stored = matching[0]
+                assert receipt == stored.to_dict()
+                assert receipt["thread_id"] == stored.thread_id == thread.id
+                assert receipt["author_id"] == stored.author_id == reply["agent_id"]
+                assert receipt["role"] == stored.role == "agent"
+                assert receipt["body"] == stored.body == reply["text"]
+                assert receipt["created_at"] == stored.created_at
+                assert receipt["metadata"] == stored.metadata
+                assert receipt["id"] not in receipt_ids
+                receipt_ids.add(receipt["id"])
+            assert len(receipt_ids) == len(messages)
             writers = [episode for episode in episodes if episode.agent_ids == ["scout1"]]
             peers = [episode for episode in episodes if episode.agent_ids == ["counselor1"]]
             assert len(writers) == len(peers) == turn + 1

--- a/ui/e2e/fixtures/group-reply-identity.json
+++ b/ui/e2e/fixtures/group-reply-identity.json
@@ -1,0 +1,130 @@
+{
+  "events": [
+    {
+      "data": {
+        "author_id": "captain",
+        "created_at": 2.0,
+        "message_id": "identity-captain",
+        "role": "captain",
+        "thread_id": "identity-room"
+      },
+      "timestamp": 1000.0,
+      "type": "chat_thread_message_appended"
+    },
+    {
+      "data": {
+        "author_id": "scout1",
+        "created_at": 4.0,
+        "message_id": "identity-reply-1",
+        "role": "agent",
+        "thread_id": "identity-room"
+      },
+      "timestamp": 1000.0,
+      "type": "chat_thread_message_appended"
+    },
+    {
+      "data": {
+        "author_id": "counselor1",
+        "created_at": 5.0,
+        "message_id": "identity-reply-2",
+        "role": "agent",
+        "thread_id": "identity-room"
+      },
+      "timestamp": 1000.0,
+      "type": "chat_thread_message_appended"
+    }
+  ],
+  "history": {
+    "messages": [
+      {
+        "author_id": "captain",
+        "body": "all hands",
+        "created_at": 2.0,
+        "id": "identity-captain",
+        "metadata": { "client_message_id": "identity-send-1" },
+        "role": "captain",
+        "thread_id": "identity-room"
+      },
+      {
+        "author_id": "scout1",
+        "body": "reply::scout1",
+        "created_at": 4.0,
+        "id": "identity-reply-1",
+        "metadata": { "fanout": "ad914", "intent_id": "identity-intent-scout1" },
+        "role": "agent",
+        "thread_id": "identity-room"
+      },
+      {
+        "author_id": "counselor1",
+        "body": "reply::counselor1",
+        "created_at": 5.0,
+        "id": "identity-reply-2",
+        "metadata": { "fanout": "ad914", "intent_id": "identity-intent-counselor1" },
+        "role": "agent",
+        "thread_id": "identity-room"
+      }
+    ],
+    "thread_id": "identity-room"
+  },
+  "request": {
+    "author_id": "captain",
+    "body": "all hands",
+    "metadata": { "client_message_id": "identity-send-1" },
+    "role": "captain"
+  },
+  "response": {
+    "author_id": "captain",
+    "body": "all hands",
+    "created_at": 2.0,
+    "id": "identity-captain",
+    "metadata": { "client_message_id": "identity-send-1" },
+    "per_agent_replies": [
+      {
+        "agent_id": "scout1",
+        "callsign": "Scout",
+        "message": {
+          "author_id": "scout1",
+          "body": "reply::scout1",
+          "created_at": 4.0,
+          "id": "identity-reply-1",
+          "metadata": { "fanout": "ad914", "intent_id": "identity-intent-scout1" },
+          "role": "agent",
+          "thread_id": "identity-room"
+        },
+        "text": "reply::scout1"
+      },
+      {
+        "agent_id": "counselor1",
+        "callsign": "Troi",
+        "message": {
+          "author_id": "counselor1",
+          "body": "reply::counselor1",
+          "created_at": 5.0,
+          "id": "identity-reply-2",
+          "metadata": { "fanout": "ad914", "intent_id": "identity-intent-counselor1" },
+          "role": "agent",
+          "thread_id": "identity-room"
+        },
+        "text": "reply::counselor1"
+      }
+    ],
+    "role": "captain",
+    "thread_id": "identity-room"
+  },
+  "thread": {
+    "archived": false,
+    "created_at": 1.0,
+    "id": "identity-room",
+    "last_active_at": 1.0,
+    "metadata": {},
+    "model": null,
+    "participants": ["scout1", "counselor1"],
+    "personality_override": null,
+    "pinned": false,
+    "preprompt": null,
+    "project_id": null,
+    "task_id": null,
+    "title": "Identity room",
+    "workspace_root": null
+  }
+}

--- a/ui/e2e/group-reply-identity.spec.ts
+++ b/ui/e2e/group-reply-identity.spec.ts
@@ -1,0 +1,370 @@
+import { expect, test, type Page, type WebSocketRoute } from '@playwright/test';
+
+import fixture from './fixtures/group-reply-identity.json' with { type: 'json' };
+import { computeProcessingDelay, computeTypingDelay } from '../src/chat/staggerReplies';
+import type { AgentProfileMessage } from '../src/store/types';
+import { gotoApp, mkAgent, mkThread, mockChatApi, openGroupChat, seedAgents } from './_helpers';
+
+const GENERATION_A = 'a'.repeat(32);
+const GENERATION_B = 'b'.repeat(32);
+const room = mkThread(fixture.thread.id, fixture.thread.title, fixture.thread.participants, {
+  created_at: fixture.thread.created_at,
+  last_active_at: fixture.thread.last_active_at,
+  metadata: fixture.thread.metadata,
+});
+const otherRoom = mkThread('synthetic-empty-other-room', 'Other room', fixture.thread.participants);
+const crew = fixture.response.per_agent_replies.map(reply => mkAgent(reply.agent_id, reply.callsign));
+const revealMs = fixture.response.per_agent_replies.map((reply, index) =>
+  computeProcessingDelay(index) + computeTypingDelay(reply.message.body));
+
+interface BrowserState {
+  threadMessages: Map<string, AgentProfileMessage[]>;
+  liveGeneration: string | null;
+  liveSequence: number;
+  activeProfileThreadId: string | null;
+  typingAgent: { threadId: string; agentId: string; callsign: string } | null;
+  agents: Map<string, { isCrew: boolean }>;
+}
+
+function deferred(): { promise: Promise<void>; release: () => void } {
+  let release!: () => void;
+  const promise = new Promise<void>(resolve => { release = resolve; });
+  return { promise, release };
+}
+
+async function state(page: Page): Promise<{
+  rows: Record<string, AgentProfileMessage[]>;
+  generation: string | null;
+  sequence: number;
+  activeThread: string | null;
+  typing: BrowserState['typingAgent'];
+  knownCrew: string[];
+}> {
+  return page.evaluate(() => {
+    const current = (window as unknown as {
+      __store: { getState: () => BrowserState };
+    }).__store.getState();
+    return {
+      rows: Object.fromEntries(current.threadMessages),
+      generation: current.liveGeneration,
+      sequence: current.liveSequence,
+      activeThread: current.activeProfileThreadId,
+      typing: current.typingAgent,
+      knownCrew: [...current.agents].filter(([, agent]) => agent.isCrew).map(([id]) => id),
+    };
+  });
+}
+
+function snapshot(generation: string): string {
+  return JSON.stringify({
+    type: 'state_snapshot', timestamp: 1, stream: { generation, sequence: 0 },
+    data: {
+      agents: crew.map(agent => ({
+        id: agent.id, agent_type: agent.agentType, callsign: agent.callsign,
+        display_name: agent.displayName, pool: agent.pool, state: agent.state,
+        confidence: agent.confidence, trust: agent.trust, tier: agent.tier, isCrew: true,
+      })),
+      connections: [], pools: [], system_mode: 'active', tc_n: 0, routing_entropy: 0,
+      notifications: [],
+    },
+  });
+}
+
+async function expectCanonical(page: Page): Promise<void> {
+  await expect.poll(async () => (await state(page)).rows[room.id]?.map(message => ({
+    id: message.id, thread_id: message.threadId, author_id: message.authorId,
+    role: message.role === 'user' ? 'captain' : message.role,
+    body: message.text, created_at: message.timestamp, metadata: message.metadata,
+  }))).toEqual(fixture.history.messages);
+  const transcript = page.getByTestId('chat-transcript');
+  await expect(transcript.getByTestId('chat-msg-time')).toHaveCount(3);
+  for (const message of fixture.history.messages) {
+    const body = transcript.getByText(message.body, { exact: true });
+    await expect(body).toHaveCount(1);
+    await expect(body).toBeVisible();
+  }
+  for (const reply of fixture.response.per_agent_replies) {
+    await expect(transcript.getByText(reply.callsign, { exact: true })).toHaveCount(1);
+  }
+  const formattedTimes = await page.evaluate(messages => messages.map(message =>
+    new Date(message.created_at * 1000).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })),
+  fixture.history.messages);
+  await expect(transcript.getByTestId('chat-msg-time')).toHaveText(formattedTimes);
+  expect((await state(page)).rows[room.id].some(message => message.optimistic)).toBe(false);
+}
+
+async function expectProfileFit(page: Page, viewport: { width: number; height: number }): Promise<void> {
+  const geometry = await page.getByTitle('Close', { exact: true }).evaluate(button => {
+    let panel = button.parentElement;
+    while (panel && getComputedStyle(panel).position !== 'fixed') panel = panel.parentElement;
+    if (!panel) throw new Error('Profile close control has no fixed outer panel');
+    const bounds = button.getBoundingClientRect();
+    return {
+      panel: panel.getBoundingClientRect().toJSON(), close: bounds.toJSON(),
+      reachable: [
+        [bounds.left + 1, bounds.top + 1], [bounds.right - 1, bounds.top + 1],
+        [bounds.left + 1, bounds.bottom - 1], [bounds.right - 1, bounds.bottom - 1],
+        [bounds.left + bounds.width / 2, bounds.top + bounds.height / 2],
+      ].every(([horizontal, vertical]) => button.contains(document.elementFromPoint(horizontal, vertical))),
+    };
+  });
+  expect(geometry.reachable).toBe(true);
+  for (const bounds of [geometry.panel, geometry.close]) {
+    expect(bounds.width).toBeGreaterThan(0);
+    expect(bounds.height).toBeGreaterThan(0);
+    expect(bounds.left).toBeGreaterThanOrEqual(0);
+    expect(bounds.top).toBeGreaterThanOrEqual(0);
+    expect(bounds.right).toBeLessThanOrEqual(viewport.width);
+    expect(bounds.bottom).toBeLessThanOrEqual(viewport.height);
+  }
+  const transcript = page.getByTestId('chat-transcript');
+  const transcriptBox = await transcript.boundingBox();
+  const composerBox = await page.getByPlaceholder('Message...', { exact: true }).boundingBox();
+  expect(transcriptBox).not.toBeNull();
+  expect(composerBox).not.toBeNull();
+  expect(transcriptBox!.y + transcriptBox!.height).toBeLessThanOrEqual(composerBox!.y + 1);
+  expect(composerBox!.x).toBeGreaterThanOrEqual(geometry.panel.left);
+  expect(composerBox!.x + composerBox!.width).toBeLessThanOrEqual(geometry.panel.right);
+  expect(composerBox!.y + composerBox!.height).toBeLessThanOrEqual(geometry.panel.bottom);
+  const rows = await transcript.getByTestId('chat-msg-time').evaluateAll(times => times.map(time => {
+    const row = time.parentElement!.parentElement!;
+    return {
+      bounds: row.getBoundingClientRect().toJSON(),
+      fits: [row, ...row.querySelectorAll<HTMLElement>('div, span, p')]
+        .every(element => element.scrollWidth <= element.clientWidth + 1),
+    };
+  }));
+  expect(rows).toHaveLength(3);
+  for (const [index, row] of rows.entries()) {
+    expect(row.fits).toBe(true);
+    expect(row.bounds.left).toBeGreaterThanOrEqual(transcriptBox!.x);
+    expect(row.bounds.right).toBeLessThanOrEqual(transcriptBox!.x + transcriptBox!.width);
+    expect(row.bounds.top).toBeGreaterThanOrEqual(transcriptBox!.y);
+    expect(row.bounds.bottom).toBeLessThanOrEqual(transcriptBox!.y + transcriptBox!.height);
+    if (index > 0) expect(rows[index - 1].bounds.bottom).toBeLessThanOrEqual(row.bounds.top);
+  }
+}
+
+for (const viewport of [{ width: 1440, height: 1000 }, { width: 900, height: 1000 }]) {
+  for (const ordering of ['event-before-http', 'http-before-event', 'room-switch-during-reveal'] as const) {
+    test(`canonical group replies: ${ordering} at ${viewport.width}px`, async ({ page }, testInfo) => {
+      test.setTimeout(90000);
+      await page.setViewportSize(viewport);
+      await page.addInitScript(({ width, height }) => {
+        localStorage.setItem('hxi_profile_panel_size', JSON.stringify({ w: Math.min(1060, width - 80), h: height - 120 }));
+        localStorage.setItem('probos.workspaceFiles.collapsed', width < 1000 ? '1' : '0');
+      }, viewport);
+      expect(fixture.thread.participants).toHaveLength(2);
+      expect(crew.map(agent => agent.id)).toEqual(fixture.thread.participants);
+      expect(fixture.events.map(event => event.data.message_id)).toEqual(fixture.history.messages.map(message => message.id));
+      expect(fixture.response.per_agent_replies.map(reply => reply.message)).toEqual(fixture.history.messages.slice(1));
+      expect(revealMs).toEqual([6000, 3500]);
+
+      const sockets: WebSocketRoute[] = [];
+      const postGate = deferred();
+      const historyGate = deferred();
+      let holdHistory = false;
+      let history = { ...fixture.history, messages: [] as typeof fixture.history.messages };
+      let historyRequests = 0;
+      let historyResponses = 0;
+      let otherHistoryRequests = 0;
+      let postResponses = 0;
+      let sequence = 0;
+      const posts: unknown[] = [];
+      const mutations: string[] = [];
+      page.on('request', request => {
+        const path = new URL(request.url()).pathname;
+        if (path.startsWith('/api/') && !['GET', 'HEAD'].includes(request.method())) {
+          mutations.push(`${request.method()} ${path}`);
+        }
+      });
+      await mockChatApi(page, { threads: [room, otherRoom] });
+      await page.route('**/api/threads/*', async route => {
+        const request = route.request();
+        const path = new URL(request.url()).pathname;
+        if (request.method() === 'GET' && path === `/api/threads/${room.id}`) {
+          return route.fulfill({ json: fixture.thread });
+        }
+        if (request.method() === 'GET' && path === `/api/threads/${otherRoom.id}`) {
+          return route.fulfill({ json: otherRoom });
+        }
+        return route.fallback();
+      });
+      await page.route('**/api/threads/*/messages*', async route => {
+        const request = route.request();
+        const path = new URL(request.url()).pathname;
+        if (request.method() === 'POST' && path === `/api/threads/${room.id}/messages`) {
+          posts.push(request.postDataJSON());
+          await postGate.promise;
+          await route.fulfill({ json: fixture.response });
+          postResponses += 1;
+          return;
+        }
+        if (request.method() === 'GET' && path === `/api/threads/${room.id}/messages`) {
+          historyRequests += 1;
+          const requestedHistory = history;
+          if (holdHistory) await historyGate.promise;
+          await route.fulfill({ json: requestedHistory, headers: { 'Cache-Control': 'no-store' } });
+          historyResponses += 1;
+          return;
+        }
+        if (request.method() === 'GET' && path === `/api/threads/${otherRoom.id}/messages`) {
+          otherHistoryRequests += 1;
+          return route.fulfill({ json: { thread_id: otherRoom.id, messages: [] } });
+        }
+        return route.abort();
+      });
+      await page.routeWebSocket('**/ws/events*', socket => { sockets.push(socket); });
+      try {
+        await gotoApp(page);
+        await expect.poll(() => sockets.length).toBe(1);
+        sockets[0].send(snapshot(GENERATION_A));
+        await expect.poll(async () => (await state(page)).generation).toBe(GENERATION_A);
+        await seedAgents(page, crew);
+        await page.evaluate(() => (window as unknown as {
+          __store: { setState: (value: unknown) => void };
+        }).__store.setState({ voiceEnabled: false, callAudioEnabled: false }));
+        await openGroupChat(page, crew[0].id, room);
+        await expect.poll(() => historyResponses).toBeGreaterThan(0);
+        await expect.poll(async () => (await state(page)).rows[room.id]).toEqual([]);
+        expect((await state(page)).knownCrew).toEqual(fixture.thread.participants);
+        const transcript = page.getByTestId('chat-transcript');
+        await expect(transcript.getByTestId('chat-msg-time')).toHaveCount(0);
+        const composer = page.getByPlaceholder('Message...', { exact: true });
+        await composer.fill(fixture.request.body);
+        await composer.evaluate((element, token) => {
+          element.setAttribute('data-correlation-calls', '0');
+          element.addEventListener('keydown', event => {
+            if ((event as KeyboardEvent).key !== 'Enter') return;
+            const descriptor = Object.getOwnPropertyDescriptor(crypto, 'randomUUID');
+            const restore = (): void => {
+              if (descriptor) Object.defineProperty(crypto, 'randomUUID', descriptor);
+              else Reflect.deleteProperty(crypto, 'randomUUID');
+            };
+            Object.defineProperty(crypto, 'randomUUID', {
+              configurable: true,
+              value: () => {
+                restore();
+                element.setAttribute('data-correlation-calls', '1');
+                return token;
+              },
+            });
+            window.setTimeout(restore, 0);
+          }, { capture: true, once: true });
+        }, fixture.request.metadata.client_message_id);
+        await composer.press('Enter');
+        await expect.poll(() => posts.length).toBe(1);
+        await expect(composer).toHaveAttribute('data-correlation-calls', '1');
+        expect(posts).toEqual([{ ...fixture.request, attachment_ids: [] }]);
+        expect(postResponses).toBe(0);
+        await expect.poll(async () => (await state(page)).rows[room.id]?.map(message => ({
+          id: message.id, optimistic: message.optimistic, metadata: message.metadata,
+        }))).toEqual([{
+          id: `optimistic:${fixture.request.metadata.client_message_id}`,
+          optimistic: true, metadata: fixture.request.metadata,
+        }]);
+
+        const publish = async (eventIndex: number, generation = GENERATION_A, socket = sockets[0]): Promise<string> => {
+          const payload = JSON.stringify({ ...fixture.events[eventIndex], stream: { generation, sequence: ++sequence } });
+          socket.send(payload);
+          await expect.poll(async () => (await state(page)).sequence).toBe(sequence);
+          return payload;
+        };
+        const refreshFromEvent = async (eventIndex: number): Promise<string> => {
+          const beforeRequests = historyRequests;
+          const beforeResponses = historyResponses;
+          const payload = await publish(eventIndex);
+          await expect.poll(() => historyRequests).toBeGreaterThan(beforeRequests);
+          await expect.poll(() => historyResponses).toBeGreaterThan(beforeResponses);
+          await expectCanonical(page);
+          return payload;
+        };
+
+        if (ordering !== 'event-before-http') {
+          postGate.release();
+          await expect.poll(() => postResponses).toBe(1);
+          await expect.poll(async () => (await state(page)).typing?.agentId).toBe(crew[0].id);
+          expect((await state(page)).rows[room.id].map(message => message.id)).toEqual([fixture.history.messages[0].id]);
+          await expect(transcript.getByText(fixture.history.messages[1].body, { exact: true })).toHaveCount(0);
+        }
+
+        if (ordering === 'room-switch-during-reveal') {
+          await openGroupChat(page, crew[0].id, otherRoom);
+          await expect.poll(() => otherHistoryRequests).toBeGreaterThan(0);
+          await expect.poll(async () => (await state(page)).activeThread).toBe(otherRoom.id);
+          await expect(transcript.getByTestId('chat-msg-time')).toHaveCount(0);
+          await expect(transcript).not.toContainText('is typing');
+          await expect.poll(async () => (await state(page)).rows[room.id]?.map(message => message.id), {
+            timeout: revealMs.reduce((total, delay) => total + delay, 0) + 5000,
+          }).toEqual(fixture.history.messages.map(message => message.id));
+          expect((await state(page)).rows[otherRoom.id]).toEqual([]);
+          await expect(transcript.getByTestId('chat-msg-time')).toHaveCount(0);
+          for (const message of fixture.history.messages) await expect(transcript).not.toContainText(message.body);
+          history = fixture.history;
+          const beforeReturn = historyResponses;
+          await openGroupChat(page, crew[0].id, room);
+          await expect.poll(() => historyResponses).toBeGreaterThan(beforeReturn);
+          await expectCanonical(page);
+        } else {
+          if (ordering === 'http-before-event') {
+            await expect.poll(async () => (await state(page)).rows[room.id]?.map(message => message.id), {
+              timeout: revealMs[0] + 5000,
+            }).toEqual(fixture.history.messages.slice(0, 2).map(message => message.id));
+            await expect(transcript.getByText(fixture.history.messages[1].body, { exact: true })).toBeVisible();
+            await expect.poll(async () => (await state(page)).typing?.agentId).toBe(crew[1].id);
+            await expect(transcript.getByText(fixture.history.messages[2].body, { exact: true })).toHaveCount(0);
+          }
+          history = fixture.history;
+          holdHistory = true;
+          const beforeRequests = historyRequests;
+          const beforeResponses = historyResponses;
+          await publish(0);
+          await expect.poll(() => historyRequests).toBeGreaterThan(beforeRequests);
+          expect(historyResponses).toBe(beforeResponses);
+          if (ordering === 'event-before-http') {
+            expect(postResponses).toBe(0);
+            expect((await state(page)).rows[room.id][0].optimistic).toBe(true);
+          }
+          holdHistory = false;
+          historyGate.release();
+          await expect.poll(() => historyResponses).toBeGreaterThan(beforeResponses);
+          await expectCanonical(page);
+          if (ordering === 'event-before-http') {
+            expect(postResponses).toBe(0);
+            postGate.release();
+            await expect.poll(() => postResponses).toBe(1);
+          }
+          await expect.poll(async () => (await state(page)).typing, { timeout: revealMs[1] + 5000 }).toBeNull();
+          await expectCanonical(page);
+        }
+
+        for (let eventIndex = 0; eventIndex < fixture.events.length; eventIndex += 1) {
+          const payload = await refreshFromEvent(eventIndex);
+          sockets[0].send(payload);
+          await refreshFromEvent(eventIndex);
+        }
+        const beforeReconnect = historyResponses;
+        await sockets[0].close({ code: 1012, reason: 'group identity reconnect test' });
+        await expect.poll(() => sockets.length, { timeout: 10000 }).toBe(2);
+        sockets[1].send(snapshot(GENERATION_B));
+        await expect.poll(async () => (await state(page)).generation).toBe(GENERATION_B);
+        await expect.poll(() => historyResponses).toBeGreaterThan(beforeReconnect);
+        await expectCanonical(page);
+        sequence = 0;
+        const beforeReplay = historyResponses;
+        await publish(2, GENERATION_B, sockets[1]);
+        await expect.poll(() => historyResponses).toBeGreaterThan(beforeReplay);
+        await expectCanonical(page);
+        expect((await state(page)).rows[otherRoom.id] ?? []).toEqual([]);
+        expect(posts).toHaveLength(1);
+        expect(postResponses).toBe(1);
+        expect(mutations).toEqual([`POST /api/threads/${room.id}/messages`]);
+        await expectProfileFit(page, viewport);
+        await page.screenshot({ path: testInfo.outputPath(`group-reply-identity-${viewport.width}.png`) });
+      } finally {
+        postGate.release();
+        historyGate.release();
+      }
+    });
+  }
+}

--- a/ui/src/audio/__tests__/useMeetingVoice.test.tsx
+++ b/ui/src/audio/__tests__/useMeetingVoice.test.tsx
@@ -16,6 +16,7 @@ vi.mock('../meetingVoice', () => ({
 
 vi.mock('../voice', () => ({
   speakResponse: vi.fn(),
+  flushSpeechQueue: vi.fn(),
   onSpeechEvent: vi.fn(() => () => {}),
   stripMarkdownForSpeech: (s: string) => s,
   prewarmTts: vi.fn(),
@@ -25,23 +26,198 @@ import { useMeetingVoice } from '../useMeetingVoice';
 import { useStore } from '../../store/useStore';
 import type { PerAgentReply } from '../meetingVoice';
 import useMeetingVoiceSource from '../useMeetingVoice?raw';
-import { prewarmTts, speakResponse } from '../voice';
+import { flushSpeechQueue, prewarmTts, speakResponse } from '../voice';
 import { createVoiceProfileResolver } from '../meetingVoice';
 
 beforeEach(() => {
   mocks.speakRepliesSequentially.mockReset();
+  mocks.speakRepliesSequentially.mockImplementation(() => new Promise<void>(() => {}));
   vi.mocked(speakResponse).mockClear();
+  vi.mocked(flushSpeechQueue).mockClear();
   useStore.setState({ callAudioEnabled: false });
 });
 
 const reply = (id: string): PerAgentReply => ({ agent_id: id, text: `text-${id}` });
 
+function pendingBatch(): { promise: Promise<void>; resolve: () => void; reject: (error: Error) => void } {
+  let resolve!: () => void;
+  let reject!: (error: Error) => void;
+  const promise = new Promise<void>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
 describe('useMeetingVoice', () => {
+  it('settles once after the batch while revealing only each completed author', async () => {
+    const batch = pendingBatch();
+    mocks.speakRepliesSequentially.mockReturnValueOnce(batch.promise);
+    useStore.setState({ callAudioEnabled: true });
+    const { result, unmount } = renderHook(() => useMeetingVoice({ meetingActive: true }));
+    const onBatchSettled = vi.fn();
+    const onUtteranceEnd = vi.fn();
+    const replies = [reply('first'), reply('second')];
+    act(() => { result.current.speakReplies(replies, { onBatchSettled, onUtteranceEnd }); });
+    const deps = mocks.speakRepliesSequentially.mock.calls[0][1];
+    act(() => { deps.onSpeakingChange('first'); deps.onUtteranceStart(replies[0]); });
+    expect(onUtteranceEnd).not.toHaveBeenCalled();
+    expect(onBatchSettled).not.toHaveBeenCalled();
+    act(() => { deps.onUtteranceEnd(replies[0]); });
+    expect(onUtteranceEnd.mock.calls).toEqual([[replies[0]]]);
+    expect(onBatchSettled).not.toHaveBeenCalled();
+    act(() => { deps.onUtteranceEnd(replies[1]); });
+    expect(onUtteranceEnd.mock.calls).toEqual([[replies[0]], [replies[1]]]);
+    await act(async () => { batch.resolve(); });
+    expect(onBatchSettled).toHaveBeenCalledTimes(1);
+    expect(result.current.speakingAgentId).toBeNull();
+    unmount();
+    expect(onBatchSettled).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(['empty', 'inactive', 'muted', 'rejected', 'unmounted'] as const)(
+    'settles %s input exactly once without starting speech', (scenario) => {
+      useStore.setState({ callAudioEnabled: scenario !== 'muted' });
+      const { result, unmount } = renderHook(() => useMeetingVoice({ meetingActive: scenario !== 'inactive' }));
+      const speakReplies = result.current.speakReplies;
+      if (scenario === 'unmounted') unmount();
+      const onBatchSettled = vi.fn();
+      act(() => {
+        speakReplies(scenario === 'empty' ? [] : [reply('first')], {
+          onBatchSettled, shouldContinue: () => scenario !== 'rejected',
+        });
+      });
+      expect(onBatchSettled).toHaveBeenCalledTimes(1);
+      expect(mocks.speakRepliesSequentially).not.toHaveBeenCalled();
+      if (scenario !== 'unmounted') unmount();
+      expect(onBatchSettled).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it.each(['throw', 'reject'] as const)('settles once when the sequencer fails by %s', async (scenario) => {
+    const batch = pendingBatch();
+    mocks.speakRepliesSequentially.mockImplementationOnce(() => {
+      if (scenario === 'throw') throw new Error('sequencer failed');
+      return batch.promise;
+    });
+    useStore.setState({ callAudioEnabled: true });
+    const { result, unmount } = renderHook(() => useMeetingVoice({ meetingActive: true }));
+    const onBatchSettled = vi.fn();
+    await act(async () => {
+      result.current.speakReplies([reply('first')], { onBatchSettled });
+      if (scenario === 'reject') batch.reject(new Error('sequencer failed'));
+    });
+    expect(onBatchSettled).toHaveBeenCalledTimes(1);
+    unmount();
+    expect(onBatchSettled).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(['unmount', 'mute', 'scope', 'meeting', 'owner'] as const)(
+    'settles pending speech promptly on %s and ignores late completion', async (scenario) => {
+      const batch = pendingBatch();
+      mocks.speakRepliesSequentially.mockReturnValueOnce(batch.promise);
+      useStore.setState({ callAudioEnabled: true });
+      const { result, rerender, unmount } = renderHook((opts) => useMeetingVoice(opts), {
+        initialProps: { meetingActive: true, scopeKey: 'origin', owner: 'surface-origin' },
+      });
+      const onBatchSettled = vi.fn();
+      const onUtteranceEnd = vi.fn();
+      act(() => { result.current.speakReplies([reply('first')], { onBatchSettled, onUtteranceEnd }); });
+      const deps = mocks.speakRepliesSequentially.mock.calls[0][1];
+      expect(deps.shouldContinue()).toBe(true);
+      expect(onBatchSettled).not.toHaveBeenCalled();
+      if (scenario === 'unmount') unmount();
+      else if (scenario === 'mute') act(() => { useStore.getState().setCallAudioEnabled(false); });
+      else rerender({
+        meetingActive: scenario !== 'meeting',
+        scopeKey: scenario === 'scope' ? 'destination' : 'origin',
+        owner: scenario === 'owner' ? 'surface-next' : 'surface-origin',
+      });
+      expect(onBatchSettled).toHaveBeenCalledTimes(1);
+      expect(flushSpeechQueue).toHaveBeenCalledTimes(1);
+      expect(flushSpeechQueue).toHaveBeenCalledWith('meeting-context-ended', 'surface-origin');
+      expect(deps.shouldContinue()).toBe(false);
+      await act(async () => { deps.onUtteranceEnd(reply('first')); batch.resolve(); });
+      expect(onUtteranceEnd).not.toHaveBeenCalled();
+      expect(onBatchSettled).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it('supersedes once without letting old settlement or a rejected receipt clear the next batch', async () => {
+    const oldBatch = pendingBatch();
+    const nextBatch = pendingBatch();
+    mocks.speakRepliesSequentially.mockReturnValueOnce(oldBatch.promise).mockReturnValueOnce(nextBatch.promise);
+    useStore.setState({ callAudioEnabled: true });
+    const { result, unmount } = renderHook(() => useMeetingVoice({ meetingActive: true, owner: 'surface' }));
+    const oldSettled = vi.fn();
+    const nextSettled = vi.fn();
+    const rejectedSettled = vi.fn();
+    act(() => { result.current.speakReplies([reply('old')], { onBatchSettled: oldSettled }); });
+    const oldDeps = mocks.speakRepliesSequentially.mock.calls[0][1];
+    act(() => { result.current.speakReplies([reply('next')], { onBatchSettled: nextSettled }); });
+    const nextDeps = mocks.speakRepliesSequentially.mock.calls[1][1];
+    act(() => { nextDeps.onSpeakingChange('next'); });
+    expect(oldSettled).toHaveBeenCalledTimes(1);
+    expect(nextSettled).not.toHaveBeenCalled();
+    act(() => {
+      result.current.speakReplies([reply('stale-room')], {
+        onBatchSettled: rejectedSettled, shouldContinue: () => false,
+      });
+    });
+    await act(async () => { oldBatch.resolve(); oldDeps.onSpeakingChange(null); });
+    expect(rejectedSettled).toHaveBeenCalledTimes(1);
+    expect(oldSettled).toHaveBeenCalledTimes(1);
+    expect(nextSettled).not.toHaveBeenCalled();
+    expect(result.current.speakingAgentId).toBe('next');
+    expect(nextDeps.shouldContinue()).toBe(true);
+    unmount();
+    expect(nextSettled).toHaveBeenCalledTimes(1);
+    await act(async () => { nextBatch.resolve(); });
+    expect(nextSettled).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(['gate-exit', 'empty-supersession'] as const)('settles pending speech on %s', async (scenario) => {
+    const batch = pendingBatch();
+    mocks.speakRepliesSequentially.mockReturnValueOnce(batch.promise);
+    useStore.setState({ callAudioEnabled: true });
+    const { result, unmount } = renderHook(() => useMeetingVoice({ meetingActive: true }));
+    let allowed = true;
+    const onBatchSettled = vi.fn();
+    const emptySettled = vi.fn();
+    act(() => {
+      result.current.speakReplies([reply('first')], { onBatchSettled, shouldContinue: () => allowed });
+    });
+    const deps = mocks.speakRepliesSequentially.mock.calls[0][1];
+    expect(deps.shouldContinue()).toBe(true);
+    expect(onBatchSettled).not.toHaveBeenCalled();
+    act(() => {
+      if (scenario === 'gate-exit') allowed = false;
+      else result.current.speakReplies([], { onBatchSettled: emptySettled });
+      expect(deps.shouldContinue()).toBe(false);
+    });
+    expect(onBatchSettled).toHaveBeenCalledTimes(1);
+    expect(emptySettled).toHaveBeenCalledTimes(scenario === 'empty-supersession' ? 1 : 0);
+    expect(mocks.speakRepliesSequentially).toHaveBeenCalledTimes(1);
+    await act(async () => { batch.resolve(); });
+    unmount();
+    expect(onBatchSettled).toHaveBeenCalledTimes(1);
+    expect(emptySettled).toHaveBeenCalledTimes(scenario === 'empty-supersession' ? 1 : 0);
+  });
+
   it('test_no_speak_when_meeting_inactive', () => {
     useStore.setState({ callAudioEnabled: true });
     const { result } = renderHook(() => useMeetingVoice({ meetingActive: false }));
     act(() => { result.current.speakReplies([reply('a')]); });
     expect(mocks.speakRepliesSequentially).not.toHaveBeenCalled();
+  });
+
+  it.each([false, true])('does not flush narration without a meeting batch (active=%s)', (meetingActive) => {
+    const { unmount } = renderHook(() => useMeetingVoice({ meetingActive, owner: 'solo-narration-owner' }));
+    act(() => { useStore.setState({ callAudioEnabled: true }); });
+    act(() => { useStore.setState({ callAudioEnabled: false }); });
+    unmount();
+    expect(mocks.speakRepliesSequentially).not.toHaveBeenCalled();
+    expect(flushSpeechQueue).not.toHaveBeenCalled();
   });
 
   it('test_speaks_when_meeting_active_and_call_audio_enabled', () => {
@@ -120,18 +296,40 @@ describe('useMeetingVoice', () => {
   // when it unmounts and the Captain keeps hearing the room after leaving it.
   it('test_speak_stamps_the_owning_surface_not_the_speaker', () => {
     useStore.setState({ callAudioEnabled: true });
-    const { result } = renderHook(() =>
+    const { result, unmount } = renderHook(() =>
       useMeetingVoice({ meetingActive: true, owner: 'profile-chat-7' }),
     );
-    act(() => { result.current.speakReplies([reply('peer-1')]); });
+    const onUtteranceStart = vi.fn();
+    const onUtteranceEnd = vi.fn();
+    act(() => { result.current.speakReplies([reply('peer-1')], { onUtteranceStart, onUtteranceEnd }); });
 
     const deps = mocks.speakRepliesSequentially.mock.calls[0][1];
+    expect(deps.shouldContinue()).toBe(true);
     deps.speak('text-peer-1', undefined, 'peer-1');
 
     // Attribution is still the speaker; only the owner names the surface.
     expect(vi.mocked(speakResponse)).toHaveBeenCalledWith(
       'text-peer-1', undefined, 'peer-1', undefined, 'narration', 'profile-chat-7',
     );
+    unmount();
+    expect(flushSpeechQueue).toHaveBeenCalledTimes(1);
+    expect(flushSpeechQueue).toHaveBeenCalledWith('meeting-context-ended', 'profile-chat-7');
+    expect(deps.shouldContinue()).toBe(false);
+    act(() => {
+      deps.onUtteranceStart(reply('peer-1'));
+      deps.onUtteranceEnd(reply('peer-1'));
+    });
+    expect(onUtteranceStart).not.toHaveBeenCalled();
+    expect(onUtteranceEnd).not.toHaveBeenCalled();
+  });
+
+  it.each([undefined, ''])('does not globally flush empty batches without owner %s', (owner) => {
+    useStore.setState({ callAudioEnabled: true });
+    const { result, unmount } = renderHook(() => useMeetingVoice({ meetingActive: true, owner }));
+    act(() => { result.current.speakReplies([]); });
+    expect(mocks.speakRepliesSequentially).not.toHaveBeenCalled();
+    unmount();
+    expect(flushSpeechQueue).not.toHaveBeenCalled();
   });
 });
 

--- a/ui/src/audio/meetingVoice.ts
+++ b/ui/src/audio/meetingVoice.ts
@@ -57,6 +57,7 @@ export interface MeetingVoiceDeps {
   /** Abort check evaluated before each utterance -- lets a newer batch
    *  supersede an in-flight one (no talk-over across Captain re-sends). */
   shouldContinue?: () => boolean;
+  claimSpeech?: (reply: PerAgentReply) => boolean;
   /** Safety cap (ms) for the case where ``'end'`` never fires (TTS
    *  unavailable). When omitted, a LENGTH-PROPORTIONAL cap is computed from
    *  the reply text (BF-615) so a long reply is never cut off mid-utterance.
@@ -169,6 +170,10 @@ export async function speakRepliesSequentially(
       profile = undefined; // Tier-2: distinct-voice -> same-voice degrade.
     }
     if (deps.shouldContinue && !deps.shouldContinue()) break;
+    if (deps.claimSpeech && !deps.claimSpeech(reply)) {
+      deps.onUtteranceEnd?.(reply);
+      continue;
+    }
     deps.onSpeakingChange?.(reply.agent_id);
     deps.onUtteranceStart?.(reply);
     let _spoken = false;

--- a/ui/src/audio/useMeetingVoice.ts
+++ b/ui/src/audio/useMeetingVoice.ts
@@ -6,7 +6,7 @@
  *  talk-over across re-sends). */
 
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { speakResponse, onSpeechEvent, stripMarkdownForSpeech, prewarmTts } from './voice';
+import { speakResponse, onSpeechEvent, stripMarkdownForSpeech, prewarmTts, flushSpeechQueue } from './voice';
 import {
   speakRepliesSequentially,
   createVoiceProfileResolver,
@@ -28,6 +28,7 @@ export interface UseMeetingVoiceOptions {
    *  serve as the owner. Bound here rather than pushed into ``MeetingVoiceDeps``
    *  because ownership is the CALLER's fact; the sequencer has no surface. */
   owner?: string;
+  scopeKey?: string | null;
 }
 
 /** BF-621: optional per-utterance reveal hooks. When supplied, the caller can
@@ -39,6 +40,9 @@ export interface UseMeetingVoiceOptions {
 export interface SpeakRepliesHooks {
   onUtteranceStart?: (reply: PerAgentReply) => void;
   onUtteranceEnd?: (reply: PerAgentReply) => void;
+  onBatchSettled?: () => void;
+  claimSpeech?: (reply: PerAgentReply) => boolean;
+  shouldContinue?: () => boolean;
 }
 
 export interface UseMeetingVoiceResult {
@@ -66,11 +70,25 @@ export function useMeetingVoice(opts: UseMeetingVoiceOptions): UseMeetingVoiceRe
   // Captain sends never talk over each other, and a stale onSpeakingChange
   // from a superseded batch can't clobber the current speakingAgentId.
   const genRef = useRef(0);
+  const batchSettledRef = useRef<(() => void) | null>(null);
+  const mountedRef = useRef(false);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => { mountedRef.current = false; };
+  }, []);
   const resolverRef = useRef(createVoiceProfileResolver());
   // Read at speak time, like every other gate here, so a reference-stable
   // ``speakReplies`` never closes over a stale owner.
   const ownerRef = useRef(opts.owner);
   useEffect(() => { ownerRef.current = opts.owner; }, [opts.owner]);
+  const callAudioEnabled = useStore((state) => state.callAudioEnabled);
+  useEffect(() => () => {
+    genRef.current += 1;
+    const hadActiveBatch = batchSettledRef.current !== null;
+    batchSettledRef.current?.();
+    setSpeakingAgentId(null);
+    if (hadActiveBatch && opts.owner) flushSpeechQueue('meeting-context-ended', opts.owner);
+  }, [opts.scopeKey, opts.owner, opts.meetingActive, callAudioEnabled]);
 
   // AD-972: move the cold voice-profile fetch + TTS backend probe OFF the
   // first-utterance critical path. When the meeting opens we prewarm the TTS
@@ -90,34 +108,74 @@ export function useMeetingVoice(opts: UseMeetingVoiceOptions): UseMeetingVoiceRe
   }, [opts.meetingActive, participantKey]);
 
   const speakReplies = useCallback((replies: PerAgentReply[], hooks?: SpeakRepliesHooks): void => {
-    if (!meetingActiveRef.current) return;
+    let settled = false;
+    const settle = (): void => {
+      if (settled) return;
+      settled = true;
+      if (batchSettledRef.current === settle) {
+        batchSettledRef.current = null;
+        if (mountedRef.current) setSpeakingAgentId(null);
+      }
+      hooks?.onBatchSettled?.();
+    };
+    if (!mountedRef.current || !meetingActiveRef.current) {
+      settle();
+      return;
+    }
     // AD-949: gate on the call-scoped ``callAudioEnabled`` (default ON) instead
     // of the Ship's-Computer ``voiceEnabled`` — group/meeting voice is now
     // audible by default in a live call and muted only via the in-call control.
-    if (!useStore.getState().callAudioEnabled) return;
-    if (!Array.isArray(replies) || replies.length === 0) return;
+    if (!useStore.getState().callAudioEnabled || !(hooks?.shouldContinue?.() ?? true)) {
+      settle();
+      return;
+    }
     const myGen = ++genRef.current;
+    batchSettledRef.current?.();
+    batchSettledRef.current = settle;
+    setSpeakingAgentId(null);
+    if (!Array.isArray(replies) || replies.length === 0) {
+      settle();
+      return;
+    }
+    const owner = ownerRef.current;
+    const shouldContinue = (): boolean => {
+      const active = !settled && genRef.current === myGen
+        && mountedRef.current
+        && meetingActiveRef.current && useStore.getState().callAudioEnabled
+        && (hooks?.shouldContinue?.() ?? true);
+      if (!active) settle();
+      return active;
+    };
     // AD-972: kick off ALL reply profile fetches up front (promise-cached, so
     // this dedupes with the meeting-open prewarm). By the time the sequential
     // sequencer awaits speaker N, its profile is resolved / in-flight — no cold
     // fetch gap between speakers.
-    for (const r of replies) void resolverRef.current(r.agent_id);
-    void speakRepliesSequentially(replies, {
-      // ``'narration'`` is ``speakResponse``'s default, so this wrapper changes
-      // nothing but the owner it stamps on each entry.
-      speak: (text, profile, agentId) => speakResponse(
-        text, profile, agentId, undefined, 'narration', ownerRef.current,
-      ),
-      subscribe: onSpeechEvent,
-      resolveProfile: resolverRef.current,
-      strip: stripMarkdownForSpeech,
-      onSpeakingChange: (id) => { if (genRef.current === myGen) setSpeakingAgentId(id); },
-      // BF-621: gen-guard the reveal hooks so a superseded batch never labels
-      // or reveals stale text (mirrors the onSpeakingChange guard).
-      onUtteranceStart: (r) => { if (genRef.current === myGen) hooks?.onUtteranceStart?.(r); },
-      onUtteranceEnd: (r) => { if (genRef.current === myGen) hooks?.onUtteranceEnd?.(r); },
-      shouldContinue: () => genRef.current === myGen,
-    });
+    try {
+      for (const reply of replies) void resolverRef.current(reply.agent_id).catch(() => undefined);
+      void Promise.resolve(speakRepliesSequentially(replies, {
+        // ``'narration'`` is ``speakResponse``'s default, so this wrapper changes
+        // nothing but the owner it stamps on each entry.
+        speak: (text, profile, agentId) => speakResponse(
+          text, profile, agentId, undefined, 'narration', owner,
+        ),
+        subscribe: onSpeechEvent,
+        resolveProfile: resolverRef.current,
+        strip: stripMarkdownForSpeech,
+        onSpeakingChange: (id) => {
+          if (shouldContinue() || (id === null && mountedRef.current && genRef.current === myGen)) {
+            setSpeakingAgentId(id);
+          }
+        },
+        // BF-621: gen-guard the reveal hooks so a superseded batch never labels
+        // or reveals stale text (mirrors the onSpeakingChange guard).
+        onUtteranceStart: (r) => { if (shouldContinue()) hooks?.onUtteranceStart?.(r); },
+        onUtteranceEnd: (r) => { if (shouldContinue()) hooks?.onUtteranceEnd?.(r); },
+        claimSpeech: hooks?.claimSpeech,
+        shouldContinue,
+      })).then(settle, settle);
+    } catch {
+      settle();
+    }
   }, []);
 
   return { speakReplies, speakingAgentId };

--- a/ui/src/chat/staggerReplies.ts
+++ b/ui/src/chat/staggerReplies.ts
@@ -21,10 +21,13 @@
 
 /** One entry of the AD-914 ``per_agent_replies`` array (mirrors AD-921's
  *  ``PerAgentReply`` — kept local so this module has no audio dependency). */
+import type { ThreadMessageDTO } from '../components/sidebar/threadApi';
+
 export interface StaggerReply {
   agent_id: string;
   callsign?: string;
   text: string;
+  message?: ThreadMessageDTO | null;
 }
 
 /** AD-960: natural-pacing timing model. Exported as the single source of truth

--- a/ui/src/components/profile/ProfileChatTab.tsx
+++ b/ui/src/components/profile/ProfileChatTab.tsx
@@ -50,8 +50,10 @@ import type {
 // AD-936 ChatMessageRow precedent; keeps the heavy audio deps out of the test).
 import {
   selectTranscriptMessages, threadDtoToMessage, buildTranscriptItems,
+  groupReplyToMessage,
   admitMessages, claimSpeech, speechScopeKey, speechKeyFor,
   sharedSpeechLedger, markScopeSeen,
+  captainReplyToMessage,
 } from './profileTranscript';
 import { ModulationIndicator } from './ModulationIndicator';
 import { GroupChatHeader } from './GroupChatHeader';
@@ -697,6 +699,7 @@ export function ProfileChatTab({ agentId, threadId }: Props) {
     transcriptInFlightRef.current.add(targetThreadId);
     const requestId = ++transcriptRequestRef.current;
     const authority = useStore.getState();
+    const baseline = authority.threadMessages.get(targetThreadId) ?? [];
     // BF-720: capture the AUTHORITY this transcript is fetched under, and only
     // that. ``liveGeneration`` identifies the stream whose state the server is
     // serving; if it changes mid-fetch the result describes a world this client
@@ -751,6 +754,7 @@ export function ProfileChatTab({ agentId, threadId }: Props) {
       current.setThreadMessages(
         targetThreadId,
         outcome.messages.map(message => threadDtoToMessage(message, current.agents)),
+        baseline,
       );
       // BF-718: a load with no trigger message is a whole transcript arriving
       // at once — opening the thread, or the reconnect repair replaying what
@@ -986,6 +990,7 @@ export function ProfileChatTab({ agentId, threadId }: Props) {
     meetingActive,
     participantAgentIds: meetingParticipantIds,
     owner: speechOwner,
+    scopeKey: activeThreadId,
   });
   // AD-985: mirror the live speakingAgentId into a ref so the relocated arm
   // effect's echo-gate predicate reads the CURRENT value at callback time
@@ -1304,9 +1309,16 @@ export function ProfileChatTab({ agentId, threadId }: Props) {
   // NOT deferred — `speakMeetingReplies` is only ever handed group fan-out
   // replies, so deferring a call would silence it entirely.
   // `isOutputAudioEnabledNow` already resolves call audio for that case.
-  // The group bail-out still CLAIMS first, so a room's backlog is not read
-  // aloud the moment it stops being a group.
   const defersToMeetingSequencer = meetingParticipantIds.length >= 2;
+  const deferredSpeechRef = useRef({ scopeKey: '', ids: new Set<string>() });
+  const groupSpeechEpochRef = useRef(0);
+  useEffect(() => () => {
+    groupSpeechEpochRef.current += 1;
+    const state = useStore.getState();
+    if (state.typingAgent?.threadId === activeThreadId) {
+      state.setTypingAgent(null);
+    }
+  }, [activeThreadId, meetingActive, callAudioEnabled]);
 
   // BF-764 / AD-1291: a refresh that admits two or more arrivals used to speak
   // them in one synchronous pass, and `speakResponse` CANCELLED in-flight audio
@@ -1335,6 +1347,34 @@ export function ProfileChatTab({ agentId, threadId }: Props) {
     const scopeKey = speechScopeKey(activeThreadId, agentId);
     const firstSight = markScopeSeen(speechLedgerRef.current, scopeKey);
     const seed = firstSight || speechSeedScopesRef.current.delete(scopeKey);
+    if (deferredSpeechRef.current.scopeKey !== scopeKey) {
+      deferredSpeechRef.current = { scopeKey, ids: new Set<string>() };
+    }
+    const deferredIds = deferredSpeechRef.current.ids;
+    const projectedMessages = messages.slice(-200);
+    const projectedIds = new Set(projectedMessages.map(msg => msg.id));
+    for (const id of deferredIds) {
+      if (!projectedIds.has(id)) deferredIds.delete(id);
+    }
+    if (defersToMeetingSequencer && meetingActive) {
+      const historicalMessages = projectedMessages.filter(msg => seed
+        && !speechLiveIdsRef.current.has(msg.id) && !deferredIds.has(msg.id));
+      admitMessages(speechLedgerRef.current, scopeKey, historicalMessages, {
+        seed: true, defaultAuthorId: agentId,
+      });
+      for (const msg of projectedMessages) {
+        if (!seed || speechLiveIdsRef.current.has(msg.id)) {
+          deferredIds.add(msg.id);
+          speechLiveIdsRef.current.delete(msg.id);
+        }
+      }
+      return;
+    }
+    admitMessages(speechLedgerRef.current, scopeKey,
+      projectedMessages.filter(msg => deferredIds.has(msg.id)), {
+        seed: true, defaultAuthorId: agentId,
+      });
+    deferredIds.clear();
     const arrivals = admitMessages(speechLedgerRef.current, scopeKey, messages, {
       seed, defaultAuthorId: agentId, liveIds: speechLiveIdsRef.current,
     });
@@ -1358,7 +1398,7 @@ export function ProfileChatTab({ agentId, threadId }: Props) {
       );
     }
   }, [
-    messages, activeThreadId, agentId, defersToMeetingSequencer,
+    messages, activeThreadId, agentId, defersToMeetingSequencer, meetingActive,
     isOutputAudioEnabledNow, voiceProfile, speechOwner,
   ]);
 
@@ -1422,6 +1462,7 @@ export function ProfileChatTab({ agentId, threadId }: Props) {
     // AD-1062: the Captain spoke — invalidate any in-flight call-open greeting so
     // it yields to this real turn instead of double-greeting / talking over.
     greetTokenRef.current += 1;
+    const sendGeneration = greetTokenRef.current;
 
     // AD-430b: Capture conversation history BEFORE adding current message
     const conv = useStore.getState().agentConversations.get(requestAgentId);
@@ -1447,15 +1488,6 @@ export function ProfileChatTab({ agentId, threadId }: Props) {
     // AD-938: in a thread context, mirror the optimistic Captain message into
     // the thread-keyed transcript (the displayed source). The per-agent buffer
     // append above stays for the no-thread cold-1:1 path + cross-session seed.
-    if (activeThreadId) {
-      useStore.getState().appendThreadMessage(activeThreadId, {
-        id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
-        role: 'user',
-        text: displayText,
-        timestamp: Date.now() / 1000,
-      });
-    }
-
     const attachmentIds = pendingAttachments.map(a => a.attachment_id);
     setPendingAttachments([]);
 
@@ -1480,6 +1512,26 @@ export function ProfileChatTab({ agentId, threadId }: Props) {
         (id) => id !== 'captain' && _agents.get(id)?.isCrew,
       ).length;
       if (_thread && crewParticipantCount >= 2) {
+        const speechEpoch = groupSpeechEpochRef.current;
+        const clientMessageId = globalThis.crypto?.randomUUID?.()
+          ?? `${Date.now()}-${Math.random().toString(36).slice(2, 12)}`;
+        useStore.getState().reconcileThreadMessage(groupThreadId, {
+          id: `optimistic:${clientMessageId}`,
+          threadId: groupThreadId,
+          role: 'user',
+          authorId: 'captain',
+          optimistic: true,
+          metadata: { client_message_id: clientMessageId },
+          text: displayText,
+          timestamp: Date.now() / 1000,
+        });
+        const setGroupTyping = (typing: Parameters<ReturnType<typeof useStore.getState>['setTypingAgent']>[0]): void => {
+          const owner = transcriptOwnerRef.current;
+          const state = useStore.getState();
+          if (greetTokenRef.current !== sendGeneration || groupSpeechEpochRef.current !== speechEpoch) return;
+          if (owner.agentId !== requestAgentId || owner.threadId !== groupThreadId) return;
+          if (typing !== null || state.typingAgent?.threadId === groupThreadId) state.setTypingAgent(typing);
+        };
         // AD-962 / AD-962a: fill the dead air before the first group reply.
         // AD-962a names the LIKELY first responder — if the Captain's message
         // directly addresses a crew participant by callsign ("@ezri ..." /
@@ -1487,10 +1539,10 @@ export function ProfileChatTab({ agentId, threadId }: Props) {
         // AD-962 generic "The crew" beat (byte-identical fallback). Cosmetic
         // only — the real fan-out reply still arrives correctly regardless.
         const _firstResponder = resolveFirstResponder(text, _thread.participants ?? [], _agents);
-        useStore.getState().setTypingAgent(
+        setGroupTyping(
           _firstResponder
-            ? { threadId: activeThreadId ?? null, agentId: _firstResponder.agentId, callsign: _firstResponder.callsign, verb: 'thinking' }
-            : { threadId: activeThreadId ?? null, agentId: '', callsign: 'The crew', verb: 'thinking' },
+            ? { threadId: groupThreadId, agentId: _firstResponder.agentId, callsign: _firstResponder.callsign, verb: 'thinking' }
+            : { threadId: groupThreadId, agentId: '', callsign: 'The crew', verb: 'thinking' },
         );
         try {
           // ``body`` has min_length=1 on AppendMessageRequest, so attach-only
@@ -1503,13 +1555,34 @@ export function ProfileChatTab({ agentId, threadId }: Props) {
               role: 'captain',
               body: text || '(attachment)',
               attachment_ids: attachmentIds,
+              metadata: { client_message_id: clientMessageId },
             }),
           });
           const data = await res.json();
+          const captainRow = captainReplyToMessage(data, groupThreadId, clientMessageId, useStore.getState().agents);
+          if (captainRow) useStore.getState().reconcileThreadMessage(groupThreadId, captainRow);
           // AD-914 returns {**msg.to_dict(), per_agent_replies: [{agent_id,
           // callsign, text}]}. Render each reply as an agent message; v1
           // attribution is a callsign prefix on the shared conversation.
-          const replies = Array.isArray(data?.per_agent_replies) ? data.per_agent_replies : [];
+          const receivedReplies: StaggerReply[] = Array.isArray(data?.per_agent_replies) ? data.per_agent_replies : [];
+          const replyRows = new Map<StaggerReply, AgentProfileMessage>();
+          const replies: StaggerReply[] = [];
+          for (const receipt of receivedReplies) {
+            const row = groupReplyToMessage(receipt, groupThreadId, useStore.getState().agents, () => ({
+              id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+              timestamp: Date.now() / 1000,
+            }));
+            if (!row) continue;
+            useStore.getState().addAgentMessage(requestAgentId, 'agent', row.text, { message: row });
+            const displayed = useStore.getState().threadMessages.get(groupThreadId)
+              ?.some((message) => message.id === row.id);
+            if (displayed) {
+              useStore.getState().reconcileThreadMessage(groupThreadId, row);
+            }
+            const reply = { ...receipt, text: row.text };
+            replyRows.set(reply, row);
+            replies.push(reply);
+          }
           // AD-960: the replies are in — release the composer NOW so the
           // Captain can read at a comfortable pace (and reply) WHILE the
           // AD-952 progressive reveal paces the crew responses in the
@@ -1524,31 +1597,15 @@ export function ProfileChatTab({ agentId, threadId }: Props) {
           // immediately re-sets a per-agent "{callsign} is typing" beat; the
           // meeting path leaves it cleared (AD-921 voice + AD-923 speaking
           // indicator pace the crew there).
-          useStore.getState().setTypingAgent(null);
-          // AD-936/938: commit ONE reply to both the per-agent buffer and the
-          // thread-keyed transcript with its author identity. Extracted so the
-          // instant (meeting) path and the AD-952 progressive (text) path share
-          // it (DRY).
-          const appendReply = (r: StaggerReply): void => {
-            const replyText = typeof r?.text === 'string' ? r.text : '';
-            if (!replyText) return;
-            const authorId = typeof r?.agent_id === 'string' ? r.agent_id : undefined;
-            const callsign = typeof r?.callsign === 'string' ? r.callsign : undefined;
-            // AD-936: thread the real author's agent_id + callsign onto the
-            // message so the bubble shows a per-author avatar + name label.
-            useStore.getState().addAgentMessage(requestAgentId, 'agent', replyText, { authorId, callsign });
-            // AD-938: mirror each fan-out reply into the thread transcript with
-            // its author identity (avatar + name label); no 'callsign:' text
-            // prefix — the AD-936 ChatMessageRow header shows the author.
-            if (activeThreadId) {
-              useStore.getState().appendThreadMessage(activeThreadId, {
-                id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
-                role: 'agent',
-                text: replyText,
-                timestamp: Date.now() / 1000,
-                authorId,
-                callsign,
-              });
+          setGroupTyping(null);
+          const appendReply = (reply: StaggerReply): void => {
+            const row = replyRows.get(reply);
+            if (row) useStore.getState().reconcileThreadMessage(groupThreadId, row);
+          };
+          const settleReplyDisplay = (): void => {
+            for (const row of replyRows.values()) {
+              useStore.getState().reconcileThreadMessage(groupThreadId, row);
+              useStore.getState().addAgentMessage(requestAgentId, 'agent', row.text, { message: row });
             }
           };
           // AD-952 + AD-976 (BF-618): human response dynamics. Reveal the
@@ -1577,26 +1634,44 @@ export function ProfileChatTab({ agentId, threadId }: Props) {
             _meetingThread?.metadata as Record<string, unknown> | undefined
           )?.meeting_active;
           const _callAudioOn = useStore.getState().callAudioEnabled;
-          if (_meetingLive && _callAudioOn) {
+          const ownsSpeech = (): boolean => greetTokenRef.current === sendGeneration
+            && groupSpeechEpochRef.current === speechEpoch
+            && transcriptOwnerRef.current.agentId === requestAgentId
+            && transcriptOwnerRef.current.threadId === groupThreadId;
+          if (!ownsSpeech()) {
+            settleReplyDisplay();
+          } else if (_meetingLive && _callAudioOn) {
             // Voice-driven reveal: hear, then see. speakMeetingReplies is
             // fire-and-forget; the hooks set the "speaking" label as each agent
             // begins and reveal that agent's text the instant it finishes.
             speakMeetingReplies(replies as PerAgentReply[], {
-              onUtteranceStart: (r) => useStore.getState().setTypingAgent({
-                threadId: activeThreadId ?? null,
+              onBatchSettled: settleReplyDisplay,
+              shouldContinue: ownsSpeech,
+              claimSpeech: (reply) => {
+                const row = replyRows.get(reply as StaggerReply);
+                return !!row && claimSpeech(
+                  speechLedgerRef.current, speechScopeKey(groupThreadId, requestAgentId), row, requestAgentId,
+                );
+              },
+              onUtteranceStart: (r) => setGroupTyping({
+                threadId: groupThreadId,
                 agentId: r.agent_id,
                 callsign: r.callsign ?? '',
                 verb: 'speaking',
               }),
               onUtteranceEnd: (r) => {
-                useStore.getState().setTypingAgent(null);
+                setGroupTyping(null);
                 appendReply(r as StaggerReply);
               },
             });
           } else {
-            await revealRepliesProgressively(replies as StaggerReply[], {
-              setTyping: (tt) => useStore.getState().setTypingAgent(
-                tt ? { threadId: activeThreadId ?? null, agentId: tt.agentId, callsign: tt.callsign } : null,
+            await revealRepliesProgressively(replies.filter((reply) => {
+              const row = replyRows.get(reply);
+              return row && !useStore.getState().threadMessages.get(groupThreadId)
+                ?.some((message) => message.id === row.id);
+            }), {
+              setTyping: (tt) => setGroupTyping(
+                tt ? { threadId: groupThreadId, agentId: tt.agentId, callsign: tt.callsign } : null,
               ),
               appendReply,
               sleep: (ms) => new Promise<void>((resolve) => setTimeout(resolve, ms)),
@@ -1605,13 +1680,22 @@ export function ProfileChatTab({ agentId, threadId }: Props) {
         } catch {
           // AD-962: clear the thinking/typing indicator on the error path so it
           // never sticks after a failed send.
-          useStore.getState().setTypingAgent(null);
+          setGroupTyping(null);
           useStore.getState().addAgentMessage(requestAgentId, 'agent', '(communication error)');
         } finally {
           setSending(false);
         }
         return;
       }
+    }
+
+    if (activeThreadId) {
+      useStore.getState().appendThreadMessage(activeThreadId, {
+        id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+        role: 'user',
+        text: displayText,
+        timestamp: Date.now() / 1000,
+      });
     }
 
     try {

--- a/ui/src/components/profile/__tests__/ProfileChatTab.groupReplyIdentity.test.tsx
+++ b/ui/src/components/profile/__tests__/ProfileChatTab.groupReplyIdentity.test.tsx
@@ -1,0 +1,936 @@
+import { act, cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../../audio/speechInput', () => ({
+  isSpeechRecognitionSupported: () => false,
+  startListening: vi.fn(),
+  stopListening: vi.fn(),
+}));
+vi.mock('../../../audio/conversationController', () => ({
+  armConversationMode: vi.fn(() => () => {}),
+  disarmConversationMode: vi.fn(),
+  markAgentReplyComplete: vi.fn(),
+}));
+vi.mock('../../../audio/transformersStt', () => ({
+  armTransformersStt: vi.fn(),
+  disarmTransformersStt: vi.fn(),
+  onTransformersTranscript: vi.fn(() => () => {}),
+  onTransformersTranscribing: vi.fn(() => () => {}),
+  onTransformersProgress: vi.fn(() => () => {}),
+}));
+vi.mock('../../../hooks/useCameraStream', () => ({
+  startCameraStream: vi.fn(async () => undefined),
+  stopCameraStream: vi.fn(async () => undefined),
+}));
+vi.mock('../MeetingView', () => ({ MeetingView: () => null }));
+vi.mock('../../workspace/WorkspaceFilesRail', () => ({ WorkspaceFilesRail: () => null }));
+
+import fixture from '../../../../e2e/fixtures/group-reply-identity.json';
+import { ProfileChatTab } from '../ProfileChatTab';
+import { formatChatTime } from '../ChatMessageRow';
+import { claimSpeech, sharedSpeechLedger, speechKeyFor, threadDtoToMessage, resetSharedSpeechLedger } from '../profileTranscript';
+import { useStore } from '../../../store/useStore';
+import type { Agent, AgentProfileMessage, WSEvent } from '../../../store/types';
+import { _resetTtsStatusForTests } from '../../../audio/voice';
+import * as voice from '../../../audio/voice';
+import { applyEmotionalModulation, PITCH_BOUNDS, RATE_BOUNDS } from '../../../audio/voiceModulation';
+import { deriveAgentSignals } from '../avatarSignals';
+import { computeProcessingDelay, computeTypingDelay } from '../../../chat/staggerReplies';
+
+const THREAD_ID = fixture.thread.id;
+const HOST_ID = fixture.thread.participants[0];
+const GENERATION = 'a'.repeat(32);
+const initialState = useStore.getState();
+
+function response(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function crewAgent(id: string, callsign: string): Agent {
+  return {
+    id, callsign, agentType: 'crew', displayName: '', pool: 'bridge',
+    state: 'active', confidence: 1, trust: 0.5, tier: 'domain',
+    isCrew: true, position: [0, 0, 0],
+  } as Agent;
+}
+
+function transcript(): AgentProfileMessage[] {
+  return useStore.getState().threadMessages.get(THREAD_ID) ?? [];
+}
+
+let resolvePost: (value: Response) => void;
+let postSettled: boolean;
+let localStorageBefore: Record<string, string>;
+let scrollIntoViewBefore: PropertyDescriptor | undefined;
+let deviceCalls: BrowserUtterance[] = [];
+
+class BrowserUtterance {
+  text: string;
+  rate = 1;
+  pitch = 1;
+  volume = 1;
+  voice: SpeechSynthesisVoice | null = null;
+  onstart: (() => void) | null = null;
+  onend: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  constructor(text: string) { this.text = text; }
+}
+
+async function endDevice(index: number): Promise<void> {
+  expect(deviceCalls[index]?.onend).toBeTypeOf('function');
+  await act(async () => { deviceCalls[index].onend!(); });
+}
+
+beforeEach(() => {
+  localStorageBefore = Object.fromEntries(
+    Object.keys(localStorage).map((key) => [key, localStorage.getItem(key) ?? '']),
+  );
+  localStorage.clear();
+  vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout', 'Date'] });
+  vi.setSystemTime(new Date('2026-09-11T22:06:07.487Z'));
+  vi.spyOn(crypto, 'randomUUID').mockReturnValue(fixture.request.metadata.client_message_id as ReturnType<Crypto['randomUUID']>);
+  resetSharedSpeechLedger();
+  _resetTtsStatusForTests();
+  scrollIntoViewBefore = Object.getOwnPropertyDescriptor(Element.prototype, 'scrollIntoView');
+  Object.defineProperty(Element.prototype, 'scrollIntoView', {
+    configurable: true, value: vi.fn(),
+  });
+  deviceCalls = [];
+  vi.stubGlobal('SpeechSynthesisUtterance', BrowserUtterance);
+  vi.stubGlobal('speechSynthesis', {
+    cancel: vi.fn(() => { deviceCalls[deviceCalls.length - 1]?.onerror?.(); }),
+    speak: vi.fn((utterance: BrowserUtterance) => { deviceCalls.push(utterance); utterance.onstart?.(); }),
+    getVoices: () => [],
+    addEventListener: vi.fn(), removeEventListener: vi.fn(),
+  });
+  postSettled = false;
+  useStore.setState({ ...initialState, liveGeneration: null, liveSequence: 0 });
+  useStore.getState().handleEvent({
+    type: 'state_snapshot',
+    data: {
+      agents: [], connections: [], pools: [], system_mode: 'active',
+      tc_n: 0, routing_entropy: 0,
+    },
+    timestamp: 1,
+    stream: { generation: GENERATION, sequence: 0 },
+  });
+  useStore.setState({
+    activeProfileAgent: HOST_ID,
+    activeProfileThreadId: THREAD_ID,
+    activeThreadId: null,
+    agents: new Map(fixture.response.per_agent_replies.map((reply) => [
+      reply.agent_id, crewAgent(reply.agent_id, reply.callsign),
+    ])),
+    chatThreads: new Map([[THREAD_ID, fixture.thread]]),
+    threadIdByAgent: new Map(),
+    threadMessages: new Map(),
+    agentConversations: new Map(),
+    artifactsByThread: new Map(),
+    selectedArtifactId: null,
+    chatDrafts: {},
+    typingAgent: null,
+    liveRepairEpoch: 0,
+    liveThreadRefresh: null,
+    voiceEnabled: false,
+    callAudioEnabled: false,
+    meetingChatVisible: true,
+  });
+});
+
+afterEach(async () => {
+  cleanup();
+  await act(async () => { deviceCalls[deviceCalls.length - 1]?.onend?.(); });
+  if (!postSettled && resolvePost) {
+    resolvePost(response({ per_agent_replies: [] }));
+    await act(async () => { await Promise.resolve(); });
+  }
+  vi.clearAllTimers();
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  if (scrollIntoViewBefore) {
+    Object.defineProperty(Element.prototype, 'scrollIntoView', scrollIntoViewBefore);
+  } else {
+    Reflect.deleteProperty(Element.prototype, 'scrollIntoView');
+  }
+  useStore.setState(initialState, true);
+  resetSharedSpeechLedger();
+  _resetTtsStatusForTests();
+  localStorage.clear();
+  for (const [key, value] of Object.entries(localStorageBefore)) localStorage.setItem(key, value);
+});
+
+describe('#1372 group reply identity', () => {
+  it('sends a group turn when secure-context randomUUID is unavailable', async () => {
+    vi.stubGlobal('crypto', { randomUUID: undefined });
+    const groupPost = vi.fn((init: RequestInit) => {
+      const request = JSON.parse(String(init.body));
+      return response({ ...fixture.response, metadata: request.metadata, per_agent_replies: [] });
+    });
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+      const url = String(input);
+      if (url === `/api/threads/${THREAD_ID}/messages` && init?.method === 'POST') return groupPost(init);
+      if (url === `/api/threads/${THREAD_ID}/messages?limit=200`) return response({ thread_id: THREAD_ID, messages: [] });
+      if (url === `/api/threads/${THREAD_ID}`) return response(fixture.thread);
+      if (url.endsWith('/chat/history')) return response({ memories: [] });
+      if (url.endsWith('/profile')) return response({ voiceProfile: null });
+      if (url.endsWith('/api/avatars/tts/status')) return response({ enabled: false, backend: 'browser' });
+      if (url === '/api/voice/health') return response({ primary_stt: 'browser', engine: 'browser', backend_available: true, healthy: true });
+      return response({});
+    }));
+    render(<ProfileChatTab agentId={HOST_ID} threadId={THREAD_ID} />);
+    await act(async () => { await Promise.resolve(); });
+    const composer = screen.getByPlaceholderText('Message...');
+    fireEvent.change(composer, { target: { value: fixture.request.body } });
+    await act(async () => { fireEvent.keyDown(composer, { key: 'Enter', code: 'Enter' }); });
+    expect(groupPost).toHaveBeenCalledTimes(1);
+    const request = JSON.parse(String(groupPost.mock.calls[0][0].body));
+    expect(request.metadata.client_message_id).toEqual(expect.any(String));
+    expect(request.metadata.client_message_id.length).toBeGreaterThan(0);
+    expect(transcript()).toHaveLength(1);
+    expect(transcript()[0].id).toBe(fixture.response.id);
+    expect(transcript()[0].metadata?.client_message_id).toBe(request.metadata.client_message_id);
+    expect(screen.getByRole('button', { name: /^Send$/ })).toBeDisabled();
+    postSettled = true;
+  });
+
+  it('replaces transient legacy group replies with authoritative rows after an in-flight refresh', async () => {
+    let holdHistory = false;
+    let resolveHistory: ((value: Response) => void) | undefined;
+    const pendingPost = new Promise<Response>((resolve) => { resolvePost = resolve; });
+    const groupPost = vi.fn(() => pendingPost);
+    const historyGet = vi.fn(() => holdHistory
+      ? new Promise<Response>(resolve => { resolveHistory = resolve; })
+      : Promise.resolve(response({ thread_id: THREAD_ID, messages: [] })));
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+      const url = String(input);
+      if (url === `/api/threads/${THREAD_ID}/messages` && init?.method === 'POST') return groupPost();
+      if (url === `/api/threads/${THREAD_ID}/messages?limit=200`) return historyGet();
+      if (url === `/api/threads/${THREAD_ID}`) return response(fixture.thread);
+      if (url.endsWith('/chat/history')) return response({ memories: [] });
+      if (url.endsWith('/profile')) return response({ voiceProfile: null });
+      if (url.endsWith('/api/avatars/tts/status')) return response({ enabled: false, backend: 'browser' });
+      if (url === '/api/voice/health') return response({ primary_stt: 'browser', engine: 'browser', backend_available: true, healthy: true });
+      return response({});
+    }));
+    render(<ProfileChatTab agentId={HOST_ID} threadId={THREAD_ID} />);
+    await act(async () => { await Promise.resolve(); });
+    expect(historyGet).toHaveBeenCalledTimes(1);
+    const composer = screen.getByPlaceholderText('Message...');
+    fireEvent.change(composer, { target: { value: fixture.request.body } });
+    await act(async () => { fireEvent.keyDown(composer, { key: 'Enter', code: 'Enter' }); });
+    expect(groupPost).toHaveBeenCalledTimes(1);
+    holdHistory = true;
+    await act(async () => {
+      useStore.getState().handleEvent({ ...fixture.events[1], stream: { generation: GENERATION, sequence: 1 } } as WSEvent);
+    });
+    expect(historyGet).toHaveBeenCalledTimes(2);
+    expect(resolveHistory).toBeTypeOf('function');
+    await act(async () => {
+      postSettled = true;
+      resolvePost(response({ ...fixture.response, per_agent_replies: fixture.response.per_agent_replies.map(({ agent_id, callsign, text }) => ({ agent_id, callsign, text })) }));
+    });
+    for (const [index, reply] of fixture.response.per_agent_replies.entries()) {
+      await act(async () => { await vi.advanceTimersByTimeAsync(computeProcessingDelay(index) + computeTypingDelay(reply.text)); });
+    }
+    expect(transcript().filter(message => message.id.startsWith('transient:'))).toHaveLength(2);
+    expect(transcript()).toHaveLength(3);
+    await act(async () => { resolveHistory!(response(fixture.history)); });
+    expect(transcript().map(message => message.id)).toEqual(fixture.history.messages.map(message => message.id));
+    const rendered = within(screen.getByTestId('chat-transcript'));
+    expect(rendered.getAllByTestId('chat-msg-time')).toHaveLength(3);
+    for (const reply of fixture.response.per_agent_replies) expect(rendered.getAllByText(reply.message.body, { exact: true })).toHaveLength(1);
+  });
+
+  it('preserves warm solo replacement when its HTTP mirror lands during a live history GET', async () => {
+    const soloThread = { ...fixture.thread, participants: [HOST_ID] };
+    const canonicalRows = fixture.history.messages.slice(0, 2);
+    const pendingPost = new Promise<Response>((resolve) => { resolvePost = resolve; });
+    let resolveHistory: ((value: Response) => void) | undefined;
+    let holdHistory = false;
+    const soloPost = vi.fn(() => pendingPost);
+    const historyGet = vi.fn(() => holdHistory
+      ? new Promise<Response>(resolve => { resolveHistory = resolve; })
+      : Promise.resolve(response({ thread_id: THREAD_ID, messages: [] })));
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+      const url = String(input);
+      if (url === `/api/agent/${HOST_ID}/chat` && init?.method === 'POST') return soloPost();
+      if (url === `/api/threads/${THREAD_ID}/messages?limit=200`) return historyGet();
+      if (url === `/api/threads/${THREAD_ID}`) return response(soloThread);
+      if (url.endsWith('/chat/history')) return response({ memories: [] });
+      if (url.endsWith('/profile')) return response({ voiceProfile: null });
+      if (url.endsWith('/api/avatars/tts/status')) return response({ enabled: false, backend: 'browser' });
+      if (url === '/api/voice/health') return response({ primary_stt: 'browser', engine: 'browser', backend_available: true, healthy: true });
+      return response({});
+    }));
+    useStore.setState({ chatThreads: new Map([[THREAD_ID, soloThread]]) });
+    render(<ProfileChatTab agentId={HOST_ID} threadId={THREAD_ID} />);
+    await act(async () => { await Promise.resolve(); });
+    expect(historyGet).toHaveBeenCalledTimes(1);
+    expect(transcript()).toEqual([]);
+    const composer = screen.getByPlaceholderText('Message...');
+    fireEvent.change(composer, { target: { value: canonicalRows[0].body } });
+    await act(async () => { fireEvent.keyDown(composer, { key: 'Enter', code: 'Enter' }); });
+    expect(soloPost).toHaveBeenCalledTimes(1);
+    holdHistory = true;
+    await act(async () => {
+      useStore.getState().handleEvent({ ...fixture.events[1], stream: { generation: GENERATION, sequence: 1 } } as WSEvent);
+    });
+    expect(historyGet).toHaveBeenCalledTimes(2);
+    expect(resolveHistory).toBeTypeOf('function');
+    await act(async () => {
+      postSettled = true;
+      resolvePost(response({ response: canonicalRows[1].body, thread_id: THREAD_ID }));
+    });
+    const localReply = transcript().find(message => message.role === 'agent');
+    expect(localReply?.text).toBe(canonicalRows[1].body);
+    expect(localReply?.id).not.toBe(canonicalRows[1].id);
+    expect(localReply?.threadId).toBeUndefined();
+    await act(async () => { resolveHistory!(response({ thread_id: THREAD_ID, messages: canonicalRows })); });
+    expect(transcript().map(message => message.id)).toEqual(canonicalRows.map(message => message.id));
+    const rendered = within(screen.getByTestId('chat-transcript'));
+    expect(rendered.getAllByText(canonicalRows[1].body, { exact: true })).toHaveLength(1);
+    expect(rendered.getAllByTestId('chat-msg-time')).toHaveLength(2);
+  });
+
+  it.each([
+    'event-first', 'http-first', 'replayed-receipt', 'same-text-distinct-id',
+    'history-seed', 'losing-claim', 'unmount', 'mute', 'room-shift', 'superseding-batch',
+    'meeting-toggle', 'pending-profile-mute', 'room-before-http',
+  ] as const)('uses real meeting audio and shared identity for %s', async (scenario) => {
+    const receipt = structuredClone(fixture.response);
+    if (scenario === 'same-text-distinct-id') {
+      const first = receipt.per_agent_replies[0];
+      receipt.per_agent_replies[1] = {
+        ...first,
+        message: { ...first.message, id: 'synthetic-negative-same-author-prose-distinct-id', created_at: 6 },
+      };
+    }
+    const replies = receipt.per_agent_replies;
+    for (const reply of replies) expect(reply.message.metadata.fanout).toBe('ad914');
+    const meetingThread = { ...fixture.thread, metadata: { ...fixture.thread.metadata, meeting_active: true } };
+    const canonicalRows = [fixture.history.messages[0], ...replies.map(reply => reply.message)];
+    let history = scenario === 'history-seed' ? canonicalRows : [];
+    const pendingPost = new Promise<Response>((resolve) => { resolvePost = resolve; });
+    const groupPost = vi.fn((_init: RequestInit): Promise<Response> => pendingPost);
+    const historyGet = vi.fn(() => response({ ...fixture.history, messages: history }));
+    const profiles = new Map(fixture.response.per_agent_replies.map((reply, index) => [
+      reply.agent_id, {
+        voice_name: `identity-voice-${index}`,
+        pitch: PITCH_BOUNDS[0] + (PITCH_BOUNDS[1] - PITCH_BOUNDS[0]) * (index + 1) / 3,
+        rate: RATE_BOUNDS[0] + (RATE_BOUNDS[1] - RATE_BOUNDS[0]) * (index + 1) / 3,
+        volume: 0.8,
+      },
+    ]));
+    let releaseProfiles!: () => void;
+    const pendingProfiles = new Promise<void>((resolve) => { releaseProfiles = resolve; });
+    const profileGet = vi.fn((id: string): Response | Promise<Response> => scenario === 'pending-profile-mute'
+      ? pendingProfiles.then(() => response({ voiceProfile: profiles.get(id) }))
+      : response({ voiceProfile: profiles.get(id) }));
+    const speechCalls = vi.spyOn(voice, 'speakResponse');
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+      const url = String(input);
+      if (url === `/api/threads/${THREAD_ID}/messages` && init?.method === 'POST') return groupPost(init);
+      if (url === `/api/threads/${THREAD_ID}/messages?limit=200`) return historyGet();
+      if (url === `/api/threads/${THREAD_ID}`) return response(meetingThread);
+      if (url.endsWith('/messages?limit=200')) return response({ messages: [], thread_id: 'synthetic-negative-other-room' });
+      if (url.endsWith('/chat/history')) return response({ memories: [] });
+      const profileAgent = fixture.thread.participants.find(id => url === `/api/agent/${id}/profile`);
+      if (profileAgent) return profileGet(profileAgent);
+      if (url.endsWith('/api/avatars/tts/status')) return response({ enabled: false, backend: 'browser' });
+      if (url === '/api/voice/health') return response({ primary_stt: 'browser', engine: 'browser', backend_available: true, healthy: true });
+      return response({});
+    }));
+    useStore.setState({ chatThreads: new Map([[THREAD_ID, meetingThread]]), callAudioEnabled: true });
+    for (const participant of fixture.thread.participants) expect(useStore.getState().agents.get(participant)?.isCrew).toBe(true);
+    const view = render(<ProfileChatTab agentId={HOST_ID} threadId={THREAD_ID} />);
+    await act(async () => { await Promise.resolve(); });
+    expect(historyGet).toHaveBeenCalledTimes(1);
+    expect(transcript().map(row => row.id)).toEqual(history.map(row => row.id));
+    expect(deviceCalls).toHaveLength(0);
+    expect(fixture.thread.participants).toHaveLength(2);
+    for (const participant of fixture.thread.participants) expect(profileGet).toHaveBeenCalledWith(participant);
+    const assertSpeaker = (deviceIndex: number, replyIndex: number): void => {
+      const reply = replies[replyIndex];
+      const profile = profiles.get(reply.agent_id)!;
+      const effective = applyEmotionalModulation(profile, deriveAgentSignals(
+        reply.agent_id,
+        useStore.getState() as unknown as Parameters<typeof deriveAgentSignals>[1],
+      ));
+      expect(deviceCalls[deviceIndex].pitch).toBeCloseTo(effective.pitch!);
+      expect(deviceCalls[deviceIndex].rate).toBeCloseTo(effective.rate!);
+      expect(speechCalls.mock.calls[deviceIndex][1]).toEqual(profile);
+      expect(speechCalls.mock.calls[deviceIndex][2]).toBe(reply.agent_id);
+      expect(speechCalls.mock.calls[deviceIndex][5]).toMatch(/^profile-chat-/);
+      expect(useStore.getState().typingAgent).toMatchObject({
+        threadId: THREAD_ID, agentId: reply.agent_id, verb: 'speaking',
+      });
+    };
+    const send = async (): Promise<void> => {
+      const composer = screen.getByPlaceholderText('Message...');
+      fireEvent.change(composer, { target: { value: fixture.request.body } });
+      await act(async () => { fireEvent.keyDown(composer, { key: 'Enter', code: 'Enter' }); });
+    };
+    await send();
+    expect(groupPost).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(String(groupPost.mock.calls[0][0].body)).metadata).toEqual(fixture.request.metadata);
+    const push = async (): Promise<void> => {
+      history = canonicalRows;
+      for (const [index, event] of fixture.events.entries()) {
+        const readsBefore = historyGet.mock.calls.length;
+        await act(async () => {
+          useStore.getState().handleEvent({
+            ...event,
+            data: {
+              ...event.data, message_id: canonicalRows[index].id,
+              author_id: canonicalRows[index].author_id, created_at: canonicalRows[index].created_at,
+            },
+            stream: { generation: GENERATION, sequence: useStore.getState().liveSequence + 1 },
+          } as WSEvent);
+        });
+        expect(historyGet.mock.calls.length).toBeGreaterThan(readsBefore);
+        expect(transcript().map(row => row.id)).toEqual(canonicalRows.map(row => row.id));
+      }
+    };
+    if (scenario === 'event-first') {
+      await push();
+      expect(postSettled).toBe(false);
+      expect(transcript().filter(row => row.role === 'agent').map(row => row.authorId))
+        .toEqual(replies.map(reply => reply.agent_id));
+      expect(deviceCalls, 'Live group hydration leaves speaking to the meeting sequencer').toHaveLength(0);
+      expect(speechCalls).not.toHaveBeenCalled();
+    }
+    if (scenario === 'losing-claim') {
+      expect(claimSpeech(sharedSpeechLedger(), THREAD_ID,
+        threadDtoToMessage(replies[0].message, useStore.getState().agents))).toBe(true);
+    }
+    const otherTyping = { threadId: 'synthetic-negative-other-room', agentId: HOST_ID, callsign: 'Other crew' };
+    const moveToOtherRoom = async (): Promise<void> => {
+      const other = { ...meetingThread, id: otherTyping.threadId };
+      await act(async () => {
+        useStore.getState().setChatThread(other);
+        useStore.setState({ activeProfileThreadId: other.id });
+        view.rerender(<ProfileChatTab agentId={HOST_ID} threadId={other.id} />);
+      });
+      await act(async () => { useStore.getState().setTypingAgent(otherTyping); });
+    };
+    const assertAcceptedRows = (): void => {
+      expect(transcript().map(row => row.id)).toEqual(canonicalRows.map(row => row.id));
+      expect(transcript().map(row => row.timestamp)).toEqual(canonicalRows.map(row => row.created_at));
+      expect(transcript().map(row => row.text)).toEqual(canonicalRows.map(row => row.body));
+      expect(useStore.getState().agentConversations.get(HOST_ID)?.messages.filter(row => row.role === 'agent'))
+        .toEqual(replies.map(reply => threadDtoToMessage(reply.message, useStore.getState().agents)));
+      expect(useStore.getState().threadMessages.get(otherTyping.threadId) ?? []).toEqual([]);
+    };
+    if (scenario === 'room-before-http') await moveToOtherRoom();
+    await act(async () => { postSettled = true; resolvePost(response(receipt)); });
+    if (scenario === 'room-before-http') {
+      assertAcceptedRows();
+      expect(deviceCalls).toHaveLength(0);
+      expect(speechCalls).not.toHaveBeenCalled();
+      expect(useStore.getState().typingAgent).toEqual(otherTyping);
+      return;
+    }
+    if (scenario === 'pending-profile-mute') {
+      expect(deviceCalls).toHaveLength(0);
+      expect(transcript().map(row => row.id)).toEqual([canonicalRows[0].id]);
+      expect(historyGet).toHaveBeenCalledTimes(1);
+      await act(async () => { useStore.getState().setCallAudioEnabled(false); });
+      assertAcceptedRows();
+      const settledRows = transcript();
+      await act(async () => { releaseProfiles(); });
+      expect(transcript()).toBe(settledRows);
+      expect(deviceCalls).toHaveLength(0);
+      expect(speechCalls).not.toHaveBeenCalled();
+      expect(useStore.getState().typingAgent).toBeNull();
+      return;
+    }
+    if (scenario === 'history-seed') {
+      expect(deviceCalls).toHaveLength(0);
+      expect(useStore.getState().typingAgent).toBeNull();
+      expect(transcript().map(row => row.id)).toEqual(canonicalRows.map(row => row.id));
+      return;
+    }
+    expect(deviceCalls.map(utterance => utterance.text)).toEqual([
+      replies[scenario === 'losing-claim' ? 1 : 0].message.body,
+    ]);
+    assertSpeaker(0, scenario === 'losing-claim' ? 1 : 0);
+    if (scenario === 'losing-claim') {
+      expect(transcript().some(row => row.id === replies[0].message.id)).toBe(true);
+      await endDevice(0);
+      expect(useStore.getState().typingAgent).toBeNull();
+      expect(transcript().map(row => row.id)).toEqual(canonicalRows.map(row => row.id));
+      return;
+    }
+    if (scenario === 'superseding-batch') {
+      expect(historyGet).toHaveBeenCalledTimes(1);
+      expect(transcript().map(row => row.id)).toEqual([canonicalRows[0].id]);
+      const nextReceipt = {
+        ...receipt,
+        per_agent_replies: replies.map(reply => ({
+          ...reply,
+          message: { ...reply.message, id: `next-batch-${reply.message.id}`, created_at: reply.message.created_at + 10 },
+        })),
+      };
+      groupPost.mockImplementationOnce(async () => response(nextReceipt));
+      await send();
+      expect(groupPost).toHaveBeenCalledTimes(2);
+      expect(transcript().map(row => row.id)).toEqual(canonicalRows.map(row => row.id));
+      await endDevice(0);
+      expect(deviceCalls).toHaveLength(2);
+      assertSpeaker(1, 0);
+      expect(transcript().map(row => row.id)).toEqual(canonicalRows.map(row => row.id));
+      await endDevice(1);
+      expect(deviceCalls).toHaveLength(3);
+      assertSpeaker(2, 1);
+      expect(transcript().map(row => row.id)).toEqual([
+        ...canonicalRows.map(row => row.id), nextReceipt.per_agent_replies[0].message.id,
+      ]);
+      await endDevice(2);
+      expect(transcript().map(row => row.id)).toEqual([
+        ...canonicalRows.map(row => row.id), ...nextReceipt.per_agent_replies.map(reply => reply.message.id),
+      ]);
+      expect(useStore.getState().threadMessages.get(otherTyping.threadId) ?? []).toEqual([]);
+      expect(useStore.getState().typingAgent).toBeNull();
+      expect(deviceCalls).toHaveLength(3);
+      return;
+    }
+    if (scenario === 'unmount' || scenario === 'mute' || scenario === 'room-shift' || scenario === 'meeting-toggle') {
+      expect(historyGet).toHaveBeenCalledTimes(1);
+      expect(transcript().map(row => row.id)).toEqual([canonicalRows[0].id]);
+      if (scenario === 'unmount') view.unmount();
+      if (scenario === 'mute') await act(async () => { useStore.getState().setCallAudioEnabled(false); });
+      if (scenario === 'room-shift') await moveToOtherRoom();
+      if (scenario === 'meeting-toggle') {
+        await act(async () => {
+          useStore.getState().setChatThread({
+            ...meetingThread, metadata: { ...meetingThread.metadata, meeting_active: false },
+          });
+        });
+      }
+      assertAcceptedRows();
+      await endDevice(0);
+      assertAcceptedRows();
+      expect(deviceCalls).toHaveLength(1);
+      expect(useStore.getState().typingAgent).toEqual(scenario === 'room-shift' ? otherTyping : null);
+      if (scenario === 'mute') {
+        expect(transcript().map(row => row.id), 'Muting audio does not discard accepted HTTP replies')
+          .toEqual(canonicalRows.map(row => row.id));
+      }
+      return;
+    }
+    if (scenario !== 'event-first') {
+      expect(transcript().some(row => row.id === replies[0].message.id)).toBe(false);
+      expect(transcript().some(row => row.id === replies[1].message.id)).toBe(false);
+    }
+    await act(async () => { await vi.advanceTimersByTimeAsync(1000); });
+    expect(deviceCalls).toHaveLength(1);
+    assertSpeaker(0, 0);
+    await endDevice(0);
+    expect(deviceCalls.map(utterance => utterance.text)).toEqual(replies.map(reply => reply.message.body));
+    assertSpeaker(1, 1);
+    expect(speechCalls.mock.calls[1][5]).toBe(speechCalls.mock.calls[0][5]);
+    if (scenario !== 'same-text-distinct-id') {
+      expect(deviceCalls[0].pitch).not.toBe(deviceCalls[1].pitch);
+      expect(deviceCalls[0].rate).not.toBe(deviceCalls[1].rate);
+    }
+    await act(async () => { await vi.advanceTimersByTimeAsync(1000); });
+    expect(deviceCalls).toHaveLength(2);
+    assertSpeaker(1, 1);
+    if (scenario !== 'event-first') {
+      expect(transcript().some(row => row.id === replies[0].message.id)).toBe(true);
+      expect(transcript().some(row => row.id === replies[1].message.id)).toBe(false);
+    }
+    await endDevice(1);
+    expect(useStore.getState().typingAgent).toBeNull();
+    expect(transcript().map(row => row.id)).toEqual(canonicalRows.map(row => row.id));
+    expect(transcript().map(row => row.timestamp)).toEqual(canonicalRows.map(row => row.created_at));
+    const memoryBeforeReplay = useStore.getState().agentConversations.get(HOST_ID)!.messages;
+    const replyMemory = memoryBeforeReplay.filter(message => message.role === 'agent');
+    expect(replyMemory).toEqual(replies.map(reply => threadDtoToMessage(reply.message, useStore.getState().agents)));
+    await push();
+    expect(useStore.getState().agentConversations.get(HOST_ID)!.messages).toBe(memoryBeforeReplay);
+    if (scenario === 'replayed-receipt') {
+      groupPost.mockImplementationOnce(async () => response(receipt));
+      await send();
+      expect(groupPost).toHaveBeenCalledTimes(2);
+      expect(useStore.getState().typingAgent).toBeNull();
+      const replayedMemory = useStore.getState().agentConversations.get(HOST_ID)!.messages;
+      expect(replayedMemory.filter(message => message.role === 'agent')).toEqual(replyMemory);
+      expect(replayedMemory.filter(message => message.role === 'user'))
+        .toHaveLength(memoryBeforeReplay.filter(message => message.role === 'user').length + 1);
+    }
+    expect(deviceCalls).toHaveLength(2);
+    expect(within(screen.getByTestId('chat-transcript')).getAllByTestId('chat-msg-time')).toHaveLength(3);
+  });
+
+  it.each(['text-room', 'legacy-text-room', 'roster-transition', 'meeting-transition'] as const)(
+    'keeps observed group rows silent through %s but admits new solo arrivals', async (scenario) => {
+      const delayedReceipt = structuredClone(fixture.response);
+      const startedInMeeting = scenario === 'roster-transition' || scenario === 'meeting-transition';
+      let currentThread = {
+        ...fixture.thread, metadata: { ...fixture.thread.metadata, meeting_active: startedInMeeting },
+      };
+      let history: typeof fixture.history.messages = [];
+      const pendingPost = new Promise<Response>((resolve) => { resolvePost = resolve; });
+      const groupPost = vi.fn((_init: RequestInit): Promise<Response> => pendingPost);
+      const historyGet = vi.fn(() => response({ ...fixture.history, messages: history }));
+      vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+        const url = String(input);
+        if (url === `/api/threads/${THREAD_ID}/messages` && init?.method === 'POST') return groupPost(init);
+        if (url === `/api/threads/${THREAD_ID}/messages?limit=200`) return historyGet();
+        if (url === `/api/threads/${THREAD_ID}`) return response(currentThread);
+        if (url.endsWith('/chat/history')) return response({ memories: [] });
+        if (url.endsWith('/profile')) return response({ voiceProfile: { pitch: 1, rate: 1, volume: 0.8 } });
+        if (url.endsWith('/api/avatars/tts/status')) return response({ enabled: false, backend: 'browser' });
+        if (url === '/api/voice/health') return response({ primary_stt: 'browser', engine: 'browser', backend_available: true, healthy: true });
+        return response({});
+      }));
+      useStore.setState({
+        chatThreads: new Map([[THREAD_ID, currentThread]]), voiceEnabled: true, callAudioEnabled: true,
+      });
+      expect(currentThread.participants).toHaveLength(2);
+      for (const id of currentThread.participants) expect(useStore.getState().agents.get(id)?.isCrew).toBe(true);
+      render(<ProfileChatTab agentId={HOST_ID} threadId={THREAD_ID} />);
+      await act(async () => { await Promise.resolve(); });
+      expect(historyGet).toHaveBeenCalledTimes(1);
+      expect(transcript()).toEqual([]);
+      const composer = screen.getByPlaceholderText('Message...');
+      fireEvent.change(composer, { target: { value: fixture.request.body } });
+      await act(async () => { fireEvent.keyDown(composer, { key: 'Enter', code: 'Enter' }); });
+      expect(groupPost).toHaveBeenCalledTimes(1);
+      history = structuredClone(fixture.history.messages);
+      if (scenario === 'legacy-text-room') {
+        for (const row of history) {
+          if (row.role === 'agent') Reflect.deleteProperty(row.metadata, 'fanout');
+        }
+        for (const reply of delayedReceipt.per_agent_replies) Reflect.deleteProperty(reply.message.metadata, 'fanout');
+      }
+      for (const event of fixture.events) {
+        const readsBefore = historyGet.mock.calls.length;
+        await act(async () => {
+          useStore.getState().handleEvent({
+            ...event, stream: { generation: GENERATION, sequence: useStore.getState().liveSequence + 1 },
+          } as WSEvent);
+        });
+        expect(historyGet.mock.calls.length).toBeGreaterThan(readsBefore);
+        expect(transcript().map(row => row.id)).toEqual(history.map(row => row.id));
+      }
+      expect(postSettled).toBe(false);
+      expect(transcript().filter(row => row.role === 'agent').map(row => row.authorId))
+        .toEqual(fixture.thread.participants);
+      expect(deviceCalls).toHaveLength(0);
+      const observedReplies = transcript().filter(row => row.role === 'agent');
+      expect(observedReplies).toHaveLength(2);
+      for (const row of observedReplies) {
+        expect(sharedSpeechLedger().scopes.get(THREAD_ID)?.keys.has(speechKeyFor(row, HOST_ID)))
+          .toBe(!startedInMeeting);
+      }
+      if (scenario === 'meeting-transition') {
+        currentThread = { ...currentThread, metadata: { ...currentThread.metadata, meeting_active: false } };
+        await act(async () => { useStore.getState().setChatThread(currentThread); });
+        expect(deviceCalls).toHaveLength(0);
+        for (const row of observedReplies) {
+          expect(sharedSpeechLedger().scopes.get(THREAD_ID)?.keys.has(speechKeyFor(row, HOST_ID))).toBe(true);
+        }
+        currentThread = { ...currentThread, metadata: { ...currentThread.metadata, meeting_active: true } };
+        await act(async () => { useStore.getState().setChatThread(currentThread); });
+        expect(deviceCalls).toHaveLength(0);
+      }
+      currentThread = { ...currentThread, participants: [HOST_ID] };
+      await act(async () => { useStore.getState().setChatThread(currentThread); });
+      expect(currentThread.participants.filter(id => useStore.getState().agents.get(id)?.isCrew)).toHaveLength(1);
+      expect(deviceCalls).toHaveLength(0);
+      for (const row of observedReplies) {
+        expect(sharedSpeechLedger().scopes.get(THREAD_ID)?.keys.has(speechKeyFor(row, HOST_ID))).toBe(true);
+      }
+      const newRow = {
+        ...fixture.response.per_agent_replies[0].message,
+        id: 'identity-post-transition', body: 'A genuinely new solo arrival.', created_at: 10,
+      };
+      history = [...history, newRow];
+      const readsBefore = historyGet.mock.calls.length;
+      await act(async () => {
+        useStore.getState().handleEvent({
+          ...fixture.events[1],
+          data: { ...fixture.events[1].data, message_id: newRow.id, author_id: newRow.author_id, created_at: newRow.created_at },
+          stream: { generation: GENERATION, sequence: useStore.getState().liveSequence + 1 },
+        } as WSEvent);
+      });
+      expect(historyGet.mock.calls.length).toBeGreaterThan(readsBefore);
+      expect(transcript().map(row => row.id)).toEqual(history.map(row => row.id));
+      expect(deviceCalls.map(utterance => utterance.text)).toEqual([newRow.body]);
+      await endDevice(0);
+      expect(deviceCalls).toHaveLength(1);
+      await act(async () => { postSettled = true; resolvePost(response(delayedReceipt)); });
+      expect(deviceCalls).toHaveLength(1);
+      expect(transcript().filter(row => row.role === 'agent')).toHaveLength(3);
+    },
+  );
+
+  it('keeps three canonical rendered rows when live events precede HTTP and delayed reveal', async () => {
+    vi.setSystemTime(new Date((fixture.response.created_at - 1) * 1000));
+    let history = { ...fixture.history, messages: [] as typeof fixture.history.messages };
+    const pendingPost = new Promise<Response>((resolve) => { resolvePost = resolve; });
+    const groupPost = vi.fn((_init: RequestInit): Promise<Response> => pendingPost);
+    const soloPost = vi.fn((_init: RequestInit): Response => response({ response: 'History received.' }));
+    const historyGet = vi.fn((): Response => response(history));
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+      const url = String(input);
+      const method = init?.method ?? 'GET';
+      if (url === `/api/agent/${HOST_ID}/chat` && method === 'POST') return soloPost(init!);
+      if (url === `/api/threads/${THREAD_ID}/messages` && method === 'POST') {
+        return groupPost(init!);
+      }
+      if (url === `/api/threads/${THREAD_ID}/messages?limit=200` && method === 'GET') {
+        return historyGet();
+      }
+      if (url === `/api/threads/${THREAD_ID}`) return response(fixture.thread);
+      if (url.endsWith('/chat/history')) return response({ memories: [] });
+      if (url.endsWith('/profile')) return response({ voiceProfile: null });
+      if (url.endsWith('/api/avatars/tts/status')) return response({ enabled: false, backend: 'browser' });
+      if (url === '/api/voice/health') {
+        return response({ primary_stt: 'browser', engine: 'browser', backend_available: true, healthy: true });
+      }
+      return response({});
+    }));
+
+    expect(fixture.thread.participants).toHaveLength(2);
+    for (const participant of fixture.thread.participants) {
+      expect(useStore.getState().agents.get(participant)?.isCrew).toBe(true);
+    }
+    const view = render(<ProfileChatTab agentId={HOST_ID} threadId={THREAD_ID} />);
+    await act(async () => { await Promise.resolve(); });
+    expect(historyGet).toHaveBeenCalled();
+    expect(useStore.getState().threadMessages.get(THREAD_ID)).toEqual([]);
+    expect(useStore.getState().liveGeneration).toBe(GENERATION);
+
+    const composer = screen.getByPlaceholderText('Message...');
+    fireEvent.change(composer, { target: { value: fixture.request.body } });
+    await act(async () => { fireEvent.keyDown(composer, { key: 'Enter', code: 'Enter' }); });
+    expect(groupPost).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(String(groupPost.mock.calls[0][0].body))).toEqual({ ...fixture.request, attachment_ids: [] });
+    expect(transcript()).toHaveLength(1);
+    expect(transcript()[0].text).toBe(fixture.request.body);
+    expect(transcript()[0]).toMatchObject({
+      threadId: THREAD_ID, role: 'user', authorId: 'captain', optimistic: true,
+      metadata: fixture.request.metadata,
+    });
+
+    history = fixture.history;
+    for (const [index, event] of fixture.events.entries()) {
+      const readsBefore = historyGet.mock.calls.length;
+      const frame: WSEvent = {
+        ...event, stream: { generation: GENERATION, sequence: index + 1 },
+      };
+      await act(async () => { useStore.getState().handleEvent(frame); });
+      expect(useStore.getState().liveSequence).toBe(index + 1);
+      expect(useStore.getState().liveThreadRefresh).toEqual({
+        threadId: THREAD_ID, requestId: event.data.message_id,
+      });
+      expect(historyGet.mock.calls.length).toBeGreaterThan(readsBefore);
+    }
+
+    const rendered = within(screen.getByTestId('chat-transcript'));
+    const canonicalIds = fixture.history.messages.map((message) => message.id);
+    expect(postSettled).toBe(false);
+    expect(transcript().map((message) => message.id)).toEqual(canonicalIds);
+    expect(transcript().filter((message) => message.role === 'user')).toHaveLength(1);
+    expect(transcript().filter((message) => message.role === 'agent').map((message) => message.authorId))
+      .toEqual(fixture.thread.participants);
+    expect(transcript().map((message) => message.timestamp))
+      .toEqual(fixture.history.messages.map((message) => message.created_at));
+    expect(rendered.getAllByTestId('chat-msg-time').map((element) => element.textContent))
+      .toEqual(fixture.history.messages.map((message) => formatChatTime(message.created_at)));
+    for (const message of fixture.history.messages) {
+      expect(rendered.getAllByText(message.body, { exact: true })).toHaveLength(1);
+    }
+
+    await act(async () => {
+      postSettled = true;
+      resolvePost(response(fixture.response));
+    });
+    expect(rendered.getAllByTestId('chat-msg-time')).toHaveLength(3);
+    for (const [index, reply] of fixture.response.per_agent_replies.entries()) {
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(computeProcessingDelay(index) + computeTypingDelay(reply.text));
+      });
+    }
+
+    expect(groupPost).toHaveBeenCalledTimes(1);
+    expect(useStore.getState().typingAgent).toBeNull();
+    expect.soft(rendered.getAllByTestId('chat-msg-time'), 'delayed HTTP reveal must not turn three rows into five')
+      .toHaveLength(3);
+    for (const message of fixture.history.messages) {
+      expect.soft(rendered.getAllByText(message.body, { exact: true })).toHaveLength(1);
+      expect.soft(transcript().filter((row) => row.id === message.id)).toHaveLength(1);
+      expect.soft(transcript().find((row) => row.id === message.id)?.timestamp).toBe(message.created_at);
+    }
+    expect.soft(transcript().map((message) => message.id)).toEqual(canonicalIds);
+    expect(useStore.getState().agentConversations.get(HOST_ID)?.messages
+      .filter(message => message.role === 'agent').map(message => message.text))
+      .toEqual(fixture.response.per_agent_replies.map(reply => reply.message.body));
+    const memoryBeforeReplay = useStore.getState().agentConversations.get(HOST_ID)!.messages;
+    expect(memoryBeforeReplay.filter(message => message.role === 'agent')).toEqual(
+      fixture.response.per_agent_replies.map(reply => threadDtoToMessage(reply.message, useStore.getState().agents)),
+    );
+    await act(async () => {
+      for (const [index, event] of fixture.events.entries()) {
+        useStore.getState().handleEvent({
+          ...event, stream: { generation: GENERATION, sequence: index + 1 },
+        } as WSEvent);
+      }
+    });
+    expect(useStore.getState().agentConversations.get(HOST_ID)!.messages).toBe(memoryBeforeReplay);
+    await act(async () => {
+      useStore.setState({ activeProfileThreadId: null, activeThreadId: null, threadIdByAgent: new Map() });
+      view.rerender(<ProfileChatTab agentId={HOST_ID} />);
+    });
+    const soloComposer = screen.getByPlaceholderText('Message...');
+    fireEvent.change(soloComposer, { target: { value: 'Continue with the group replies.' } });
+    await act(async () => { fireEvent.keyDown(soloComposer, { key: 'Enter', code: 'Enter' }); });
+    expect(soloPost).toHaveBeenCalledTimes(1);
+    expect(groupPost).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(String(soloPost.mock.calls[0][0].body))).toMatchObject({
+      message: 'Continue with the group replies.',
+      history: [
+        { role: 'user', text: fixture.request.body },
+        ...fixture.response.per_agent_replies.map(reply => ({ role: 'agent', text: reply.message.body })),
+      ],
+    });
+  });
+
+  it.each(['http-first', 'stale-get', 'room-switch', 'identical-sends'] as const)(
+    'keeps canonical identities and captured ownership for %s', async (scenario) => {
+      let history = { ...fixture.history, messages: [] as typeof fixture.history.messages };
+      let holdHistory = false;
+      let resolveHistory: ((value: Response) => void) | undefined;
+      const pendingPost = new Promise<Response>((resolve) => { resolvePost = resolve; });
+      const groupPost = vi.fn((_init: RequestInit): Promise<Response> => pendingPost);
+      const historyGet = vi.fn((): Response | Promise<Response> => {
+        if (holdHistory) return new Promise<Response>((resolve) => { resolveHistory = resolve; });
+        return response(history);
+      });
+      const otherThread = { ...fixture.thread, id: 'other-room', title: 'Other room' };
+      vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+        const url = String(input);
+        if (url === `/api/threads/${THREAD_ID}/messages` && init?.method === 'POST') return groupPost(init);
+        if (url === `/api/threads/${THREAD_ID}/messages?limit=200`) return historyGet();
+        if (url === `/api/threads/${THREAD_ID}`) return response(fixture.thread);
+        if (url === '/api/threads/other-room/messages?limit=200') return response({ messages: [], thread_id: 'other-room' });
+        if (url === '/api/threads/other-room') return response(otherThread);
+        if (url.endsWith('/chat/history')) return response({ memories: [] });
+        if (url.endsWith('/profile')) return response({ voiceProfile: null });
+        if (url.endsWith('/api/avatars/tts/status')) return response({ enabled: false, backend: 'browser' });
+        if (url === '/api/voice/health') return response({ primary_stt: 'browser', engine: 'browser', backend_available: true, healthy: true });
+        return response({});
+      }));
+
+      const view = render(<ProfileChatTab agentId={HOST_ID} threadId={THREAD_ID} />);
+      await act(async () => { await Promise.resolve(); });
+      expect(historyGet).toHaveBeenCalledTimes(1);
+      expect(transcript()).toEqual([]);
+      const send = async (): Promise<void> => {
+        const composer = screen.getByPlaceholderText('Message...');
+        fireEvent.change(composer, { target: { value: fixture.request.body } });
+        await act(async () => { fireEvent.keyDown(composer, { key: 'Enter', code: 'Enter' }); });
+      };
+      await send();
+      expect(groupPost).toHaveBeenCalledTimes(1);
+      expect(JSON.parse(String(groupPost.mock.calls[0][0].body))).toEqual({ ...fixture.request, attachment_ids: [] });
+      expect(transcript()).toHaveLength(1);
+      expect(transcript()[0].metadata).toEqual(fixture.request.metadata);
+
+      if (scenario === 'stale-get') {
+        holdHistory = true;
+        await act(async () => { useStore.setState({ liveRepairEpoch: useStore.getState().liveRepairEpoch + 1 }); });
+        expect(historyGet).toHaveBeenCalledTimes(2);
+        expect(resolveHistory).toBeTypeOf('function');
+      }
+
+      await act(async () => {
+        postSettled = true;
+        resolvePost(response(fixture.response));
+      });
+      expect(transcript().filter(message => message.role === 'user')).toEqual([
+        expect.objectContaining({ id: fixture.response.id, timestamp: fixture.response.created_at, metadata: fixture.response.metadata }),
+      ]);
+      expect(transcript().some(message => message.optimistic)).toBe(false);
+
+      const otherTyping = { threadId: 'other-room', agentId: HOST_ID, callsign: 'Other crew' };
+      if (scenario === 'room-switch') {
+        await act(async () => {
+          useStore.getState().setChatThread(otherThread);
+          useStore.setState({ activeProfileThreadId: 'other-room' });
+          view.rerender(<ProfileChatTab agentId={HOST_ID} threadId="other-room" />);
+        });
+        expect(useStore.getState().typingAgent).toBeNull();
+        await act(async () => { useStore.getState().setTypingAgent(otherTyping); });
+      }
+      for (const [index, reply] of fixture.response.per_agent_replies.entries()) {
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(computeProcessingDelay(index) + computeTypingDelay(reply.text));
+        });
+      }
+      const canonicalIds = fixture.history.messages.map(message => message.id);
+      expect(transcript().map(message => message.id)).toEqual(canonicalIds);
+      expect(transcript().map(message => message.timestamp)).toEqual(fixture.history.messages.map(message => message.created_at));
+
+      if (scenario === 'stale-get') {
+        await act(async () => { resolveHistory!(response(history)); });
+        holdHistory = false;
+        expect(transcript().map(message => message.id)).toEqual(canonicalIds);
+      }
+      if (scenario === 'room-switch') {
+        expect(useStore.getState().typingAgent).toEqual(otherTyping);
+        expect(useStore.getState().threadMessages.get('other-room')).toEqual([]);
+        const rendered = within(screen.getByTestId('chat-transcript'));
+        for (const message of fixture.history.messages) expect(rendered.queryByText(message.body, { exact: true })).toBeNull();
+        expect(groupPost).toHaveBeenCalledTimes(1);
+        return;
+      }
+
+      history = fixture.history;
+      for (const [index, event] of fixture.events.entries()) {
+        const readsBefore = historyGet.mock.calls.length;
+        await act(async () => {
+          useStore.getState().handleEvent({ ...event, stream: { generation: GENERATION, sequence: index + 1 } } as WSEvent);
+        });
+        expect(historyGet.mock.calls.length).toBeGreaterThan(readsBefore);
+      }
+      expect(transcript().map(message => message.id)).toEqual(canonicalIds);
+      const rendered = within(screen.getByTestId('chat-transcript'));
+      expect(rendered.getAllByTestId('chat-msg-time')).toHaveLength(3);
+      for (const message of fixture.history.messages) expect(rendered.getAllByText(message.body, { exact: true })).toHaveLength(1);
+
+      if (scenario === 'identical-sends') {
+        const secondToken = 'identity-send-2';
+        vi.mocked(crypto.randomUUID).mockReturnValue(secondToken as ReturnType<Crypto['randomUUID']>);
+        let resolveSecond!: (value: Response) => void;
+        groupPost.mockImplementationOnce(() => new Promise<Response>((resolve) => { resolveSecond = resolve; }));
+        await send();
+        expect(groupPost).toHaveBeenCalledTimes(2);
+        expect(JSON.parse(String(groupPost.mock.calls[1][0].body))).toEqual({
+          ...fixture.request, attachment_ids: [], metadata: { client_message_id: secondToken },
+        });
+        expect(transcript().filter(message => message.role === 'user')).toHaveLength(2);
+        expect(transcript().filter(message => message.role === 'user').map(message => message.metadata?.client_message_id))
+          .toEqual([fixture.request.metadata.client_message_id, secondToken]);
+        await act(async () => {
+          resolveSecond(response({
+            ...fixture.response, id: 'identity-captain-2', created_at: 6,
+            metadata: { client_message_id: secondToken }, per_agent_replies: [],
+          }));
+        });
+        expect(transcript().filter(message => message.role === 'user').map(message => message.id))
+          .toEqual([fixture.response.id, 'identity-captain-2']);
+        expect(rendered.getAllByText(fixture.request.body, { exact: true })).toHaveLength(2);
+      } else {
+        expect(groupPost).toHaveBeenCalledTimes(1);
+      }
+    },
+  );
+});

--- a/ui/src/components/profile/__tests__/ProfileChatTab.threadTranscript.test.tsx
+++ b/ui/src/components/profile/__tests__/ProfileChatTab.threadTranscript.test.tsx
@@ -17,8 +17,9 @@ vi.mock('../../sidebar/threadApi', () => ({
 import { listMessages } from '../../sidebar/threadApi';
 import {
   threadDtoToMessage, selectTranscriptMessages, loadThreadMessages,
+  groupReplyToMessage, captainReplyToMessage,
   buildTranscriptItems, transcriptDayLabel, TRANSCRIPT_RENDER_CAP, type TranscriptItem,
-  createSpeechLedger, admitMessages, isSpeakableAgentMessage, speechKeyFor,
+  createSpeechLedger, admitMessages, claimSpeech, isSpeakableAgentMessage, speechKeyFor,
   SPEECH_SCOPE_CAP,
 } from '../profileTranscript';
 import { ChatMessageRow } from '../ChatMessageRow';
@@ -76,11 +77,11 @@ afterEach(() => {
 });
 
 describe('AD-938 threadDtoToMessage', () => {
-  it('maps a captain message to a user bubble with no author identity', () => {
+  it('maps a captain message to a user bubble retaining correlation author identity', () => {
     const agents = seedAgents([]);
     const msg = threadDtoToMessage(mkDto({ id: 'm1', role: 'captain', author_id: 'captain', body: 'status?' }), agents);
     expect(msg).toMatchObject({ id: 'm1', role: 'user', text: 'status?' });
-    expect(msg.authorId).toBeUndefined();
+    expect(msg.authorId).toBe('captain');
     expect(msg.callsign).toBeUndefined();
   });
 
@@ -142,6 +143,115 @@ describe('AD-938 threadDtoToMessage', () => {
       new Map(),
     );
     expect(empty.emotion).toBeUndefined();
+  });
+});
+
+describe('group reply display identity', () => {
+  const canonical = mkDto({ id: 'reply-id', role: 'agent', author_id: 'a1', body: 'stored body' });
+
+  it('preserves the canonical body, identity, author, metadata and timestamp without a fallback', () => {
+    const fallback = vi.fn(() => ({ id: 'local', timestamp: 42 }));
+    const row = groupReplyToMessage({ agent_id: 'a1', text: 'raw body', message: canonical }, 't1', new Map(), fallback);
+    expect(row).toEqual(threadDtoToMessage(canonical, new Map()));
+    expect(fallback).not.toHaveBeenCalled();
+  });
+
+  it.each([undefined, null])('creates one transient identity for an unavailable DTO (%s)', (message) => {
+    const fallback = vi.fn(() => ({ id: 'request-reply', timestamp: 42 }));
+    const row = groupReplyToMessage({ agent_id: 'a1', text: 'legacy', message }, 't1', new Map(), fallback);
+    expect(row).toMatchObject({ id: 'transient:request-reply', threadId: 't1', text: 'legacy', timestamp: 42 });
+    expect(fallback).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    { id: '' }, { id: ' bad' }, { thread_id: 'other' }, { author_id: 'other' },
+    { role: 'captain' }, { body: '' }, { body: 42 }, { created_at: NaN },
+    { created_at: Infinity }, { created_at: -1 }, { metadata: [] },
+  ])('rejects a malformed supplied DTO without legacy fallback: %j', (invalid) => {
+    const fallback = vi.fn(() => ({ id: 'local', timestamp: 42 }));
+    const message = { ...canonical, ...invalid } as ThreadMessageDTO;
+    expect(groupReplyToMessage({ agent_id: 'a1', text: 'raw', message }, 't1', new Map(), fallback)).toBeNull();
+    expect(fallback).not.toHaveBeenCalled();
+  });
+
+  it('rejects empty legacy prose and invalid fallback identity', () => {
+    const fallback = vi.fn(() => ({ id: '', timestamp: 42 }));
+    expect(groupReplyToMessage({ agent_id: 'a1', text: '' }, 't1', new Map(), fallback)).toBeNull();
+    expect(fallback).not.toHaveBeenCalled();
+    expect(groupReplyToMessage({ agent_id: 'a1', text: 'reply' }, 't1', new Map(), fallback)).toBeNull();
+    expect(groupReplyToMessage({ agent_id: '', text: 'reply' }, 't1', new Map(), fallback)).toBeNull();
+  });
+});
+
+describe('canonical group speech claims', () => {
+  const dto = mkDto({
+    id: 'canonical-group-1', role: 'agent', author_id: 'a1', metadata: { fanout: 'ad914' },
+  });
+  const row = threadDtoToMessage(dto, new Map());
+
+  it('shares an HTTP/live claim but admits distinct IDs with identical author and prose', () => {
+    const ledger = createSpeechLedger();
+    const receipt = groupReplyToMessage({ agent_id: 'a1', text: 'raw', message: dto }, 't1', new Map(), () => {
+      throw new Error('canonical premise failed');
+    });
+    expect(receipt).not.toBeNull();
+    expect(claimSpeech(ledger, 't1', receipt!)).toBe(true);
+    expect(claimSpeech(ledger, 't1', row)).toBe(false);
+    expect(claimSpeech(ledger, 't1', { ...row, id: 'synthetic-negative-distinct-id' })).toBe(true);
+    expect(claimSpeech(ledger, 't1', { ...row, text: 'updated stored body' })).toBe(false);
+    expect(speechKeyFor({ ...row, threadId: 'other' })).not.toBe(speechKeyFor(row));
+  });
+
+  it('seeds history without consuming known live IDs silently', () => {
+    const ledger = createSpeechLedger();
+    const live = { ...row, id: 'synthetic-negative-live-id' };
+    expect(admitMessages(ledger, 't1', [row, live], { seed: true, liveIds: new Set([live.id]) })).toEqual([live]);
+    expect(claimSpeech(ledger, 't1', row)).toBe(false);
+    expect(claimSpeech(ledger, 't1', live)).toBe(false);
+    expect(admitMessages(ledger, 'empty', [], { seed: true })).toEqual([]);
+  });
+
+  it.each([
+    { metadata: undefined }, { metadata: null }, { metadata: {} }, { metadata: { fanout: 'other' } },
+    { id: '' }, { id: ' bad' }, { threadId: '' }, { authorId: '' }, { timestamp: NaN },
+    { timestamp: -1 }, { text: '' }, { role: 'user' as const },
+  ])('keeps fallback for unproven canonical group rows: %j', (change) => {
+    const candidate = { ...row, ...change };
+    expect(speechKeyFor(candidate)).toBe(
+      `${candidate.role}\u0000${candidate.authorId ?? ''}\u0000${candidate.text.trim()}`,
+    );
+  });
+
+  it.each([undefined, null])('keeps no-DTO receipts on the legacy claim: %s', (message) => {
+    const ledger = createSpeechLedger();
+    const legacy = groupReplyToMessage({ agent_id: 'a1', text: 'hello', message }, 't1', new Map(),
+      () => ({ id: 'request-local', timestamp: 1 }));
+    expect(legacy?.id).toBe('transient:request-local');
+    expect(claimSpeech(ledger, 't1', legacy!)).toBe(true);
+    expect(claimSpeech(ledger, 't1', { ...legacy!, id: 'different-local-id' })).toBe(false);
+  });
+});
+
+describe('Captain receipt identity', () => {
+  const captain = mkDto({ id: 'captain-id', role: 'captain', metadata: { client_message_id: 'token' } });
+
+  it('preserves canonical identity, body, timestamp, and correlation token', () => {
+    expect(captainReplyToMessage(captain, 't1', 'token', new Map()))
+      .toEqual(threadDtoToMessage(captain, new Map()));
+  });
+
+  it.each([
+    null, undefined, [], {}, { ...captain, id: '' }, { ...captain, thread_id: 'other' },
+    { ...captain, role: 'agent' }, { ...captain, author_id: 'other' },
+    { ...captain, body: '' }, { ...captain, created_at: NaN },
+    { ...captain, metadata: null }, { ...captain, metadata: [] },
+    { ...captain, metadata: { client_message_id: 'different' } },
+  ])('rejects missing, invalid, or uncorrelated receipts: %j', (value) => {
+    expect(captainReplyToMessage(value, 't1', 'token', new Map())).toBeNull();
+  });
+
+  it.each(['', ' ', null, undefined])('rejects invalid request tokens: %j', (token) => {
+    expect(captainReplyToMessage(captain, 't1', token as string, new Map())).toBeNull();
   });
 });
 

--- a/ui/src/components/profile/profileTranscript.ts
+++ b/ui/src/components/profile/profileTranscript.ts
@@ -6,6 +6,7 @@
 // independently testable. ProfileChatTab imports ``selectTranscriptMessages``
 // (render source switch) and ``loadThreadMessages`` (the load-on-open effect).
 import type { Agent, AgentProfileMessage } from '../../store/types';
+import type { StaggerReply } from '../../chat/staggerReplies';
 import { listMessages, type ThreadMessageDTO } from '../sidebar/threadApi';
 
 /** Map a persisted thread message (GET /messages DTO) into the profile
@@ -24,14 +25,71 @@ export function threadDtoToMessage(
   const rawEmotion = m.metadata?.emotion;
   return {
     id: m.id,
+    threadId: m.thread_id,
+    metadata: m.metadata,
     role: m.role === 'captain' ? 'user' : (isAgent ? 'agent' : 'system'),
     text: m.body,
     timestamp: m.created_at,
-    authorId: isAgent ? m.author_id : undefined,
+    authorId: isAgent || m.role === 'captain' ? m.author_id : undefined,
     callsign: isAgent ? (agents.get(m.author_id)?.callsign ?? undefined) : undefined,
     emotion: typeof rawEmotion === 'string' && rawEmotion.length > 0
       ? rawEmotion
       : undefined,
+  };
+}
+
+function validId(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0 && value.length <= 128
+    && value.trim() === value && !/[\u0000-\u001f\u007f]/.test(value);
+}
+
+function validThreadMessage(
+  value: unknown, threadId: string, authorId: string, role: string,
+): value is ThreadMessageDTO {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const message = value as ThreadMessageDTO;
+  return validId(threadId) && validId(authorId) && validId(message.id)
+    && message.thread_id === threadId && message.author_id === authorId && message.role === role
+    && typeof message.body === 'string' && !!message.body.trim()
+    && typeof message.created_at === 'number' && Number.isFinite(message.created_at)
+    && message.created_at >= 0
+    && (message.metadata === undefined || message.metadata === null
+      || (typeof message.metadata === 'object' && !Array.isArray(message.metadata)));
+}
+
+export function captainReplyToMessage(
+  value: unknown, threadId: string, clientMessageId: string, agents: Map<string, Agent>,
+): AgentProfileMessage | null {
+  if (!validId(clientMessageId) || !validThreadMessage(value, threadId, 'captain', 'captain')
+    || value.metadata?.client_message_id !== clientMessageId) return null;
+  return threadDtoToMessage(value, agents);
+}
+
+export function groupReplyToMessage(
+  reply: StaggerReply,
+  threadId: string,
+  agents: Map<string, Agent>,
+  createFallback: () => { id: string; timestamp: number },
+): AgentProfileMessage | null {
+  if (!reply || !validId(threadId) || !validId(reply.agent_id)) return null;
+  if (reply.message !== undefined && reply.message !== null) {
+    const message = reply.message;
+    if (!validThreadMessage(message, threadId, reply.agent_id, 'agent')) {
+      return null;
+    }
+    return threadDtoToMessage(message, agents);
+  }
+  if (typeof reply.text !== 'string' || !reply.text.trim()) return null;
+  const fallback = createFallback();
+  if (!validId(fallback.id) || !Number.isFinite(fallback.timestamp) || fallback.timestamp < 0) return null;
+  return {
+    id: `transient:${fallback.id}`,
+    threadId,
+    role: 'agent',
+    text: reply.text,
+    timestamp: fallback.timestamp,
+    authorId: reply.agent_id,
+    callsign: typeof reply.callsign === 'string' ? reply.callsign : undefined,
   };
 }
 
@@ -187,7 +245,8 @@ export function markScopeSeen(ledger: SpeechLedger, scopeKey: string): boolean {
   return first;
 }
 
-/** Identity for speech: role + author + trimmed text, NOT the message id.
+/** Canonical AD-914 group rows use thread + message identity. Other rows keep
+ *  the legacy role + author + trimmed text fallback described below.
  *
  *  ``sendText`` appends its reply locally with a generated id and the server's
  *  own append then replaces it with the canonical row under a different id.
@@ -210,9 +269,17 @@ export function markScopeSeen(ledger: SpeechLedger, scopeKey: string): boolean {
  *  cannot collide, so there is deliberately no second guard here to drift out
  *  of step with this one. */
 export function speechKeyFor(
-  msg: Pick<AgentProfileMessage, 'authorId' | 'text' | 'role'>,
+  msg: Pick<AgentProfileMessage, 'authorId' | 'text' | 'role'>
+    & Partial<Pick<AgentProfileMessage, 'id' | 'threadId' | 'timestamp' | 'metadata'>>,
   defaultAuthorId = '',
 ): string {
+  if (msg.metadata?.fanout === 'ad914' && msg.role === 'agent'
+    && validThreadMessage({
+      id: msg.id, thread_id: msg.threadId, author_id: msg.authorId,
+      role: msg.role, body: msg.text, created_at: msg.timestamp, metadata: msg.metadata,
+    }, msg.threadId ?? '', msg.authorId ?? '', 'agent')) {
+    return `group\u0000${msg.threadId}\u0000${msg.id}`;
+  }
   return `${msg.role ?? ''}\u0000${msg.authorId || defaultAuthorId}\u0000${(msg.text ?? '').trim()}`;
 }
 

--- a/ui/src/store/__tests__/threadMessages.test.ts
+++ b/ui/src/store/__tests__/threadMessages.test.ts
@@ -1,7 +1,7 @@
 // AD-938: tests for the thread-keyed display-transcript store slice
 // (threadMessages + setThreadMessages/appendThreadMessage). Real zustand store
 // via useStore.getState()/setState (BF-287 real-fixture style, no MagicMock).
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { useStore } from '../useStore';
 import type { AgentProfileMessage } from '../types';
 
@@ -11,6 +11,262 @@ function mkMsg(id: string, role: AgentProfileMessage['role'] = 'agent'): AgentPr
 
 afterEach(() => {
   useStore.setState({ threadMessages: new Map() });
+});
+
+describe('group reply memory', () => {
+  const initialConversations = useStore.getState().agentConversations;
+  const initialProfile = useStore.getState().activeProfileAgent;
+  const row = (id = 'reply', threadId = 't1'): AgentProfileMessage => ({
+    id, threadId, role: 'agent', authorId: 'crew', callsign: 'Crew',
+    text: 'same words', timestamp: 42, metadata: { fanout: 'ad914', emotion: 'calm' },
+    emotion: 'calm',
+  });
+  const mirror = (message: AgentProfileMessage): void => {
+    useStore.getState().addAgentMessage('host', 'agent', message.text, { message });
+  };
+  beforeEach(() => {
+    useStore.setState({ agentConversations: new Map(), activeProfileAgent: null });
+  });
+  afterEach(() => {
+    useStore.setState({ agentConversations: initialConversations, activeProfileAgent: initialProfile });
+  });
+
+  it('preserves memory fields and leaves retained identity replay and unread count unchanged', () => {
+    mirror(row());
+    const before = useStore.getState().agentConversations;
+    expect(before.get('host')?.messages).toEqual([row()]);
+    expect(before.get('host')?.unreadCount).toBe(1);
+    mirror(row());
+    expect(useStore.getState().agentConversations).toBe(before);
+  });
+
+  it('keeps same prose with distinct IDs and the same ID from distinct threads in memory', () => {
+    mirror(row());
+    mirror(row('other'));
+    mirror(row('reply', 't2'));
+    expect(useStore.getState().agentConversations.get('host')?.messages)
+      .toEqual([row(), row('other'), row('reply', 't2')]);
+    expect(useStore.getState().agentConversations.get('host')?.unreadCount).toBe(3);
+  });
+
+  it('deduplicates memory before the 100-row cap without moving retained identities', () => {
+    const messages = Array.from({ length: 101 }, (_, index) => row(`reply-${index}`));
+    for (const message of messages.slice(0, 100)) mirror(message);
+    const before = useStore.getState().agentConversations;
+    mirror(messages[0]);
+    expect(useStore.getState().agentConversations).toBe(before);
+    mirror(messages[100]);
+    expect(useStore.getState().agentConversations.get('host')?.messages).toEqual(messages.slice(1));
+    expect(useStore.getState().agentConversations.get('host')?.unreadCount).toBe(101);
+  });
+
+  it.each([
+    { id: '' }, { id: ' padded ' }, { id: 'bad\nidentity' }, { id: 'x'.repeat(129) },
+    { threadId: undefined }, { threadId: '' }, { authorId: '' }, { authorId: undefined },
+    { text: '' }, { text: ' ' }, { timestamp: NaN }, { timestamp: Infinity }, { timestamp: -1 },
+    { role: 'user' }, { optimistic: true }, { metadata: [] }, { metadata: 'invalid' },
+  ])('rejects invalid memory input without mutation: %j', (invalid) => {
+    const before = useStore.getState().agentConversations;
+    mirror({ ...row(), ...invalid } as AgentProfileMessage);
+    expect(useStore.getState().agentConversations).toBe(before);
+  });
+
+  it('rejects null memory rows and mismatched call arguments without mutation', () => {
+    const store = useStore.getState();
+    const before = store.agentConversations;
+    store.addAgentMessage('host', 'agent', 'same words', { message: null as unknown as AgentProfileMessage });
+    store.addAgentMessage('', 'agent', 'same words', { message: row() });
+    store.addAgentMessage('host', 'user', 'same words', { message: row() });
+    store.addAgentMessage('host', 'agent', 'different words', { message: row() });
+    store.addAgentMessage('host', 'agent', 'same words', { message: row(), authorId: 'other' });
+    expect(useStore.getState().agentConversations).toBe(before);
+  });
+
+  it.each([undefined, null])('accepts memory without metadata: %j', (metadata) => {
+    const message = { ...row(), metadata };
+    useStore.setState({ activeProfileAgent: 'host' });
+    mirror(message);
+    expect(useStore.getState().agentConversations.get('host')?.messages).toEqual([message]);
+    expect(useStore.getState().agentConversations.get('host')?.unreadCount).toBe(0);
+  });
+
+  it('reuses transient request identity without claiming persistence', () => {
+    const message = { ...row('transient:request-reply'), metadata: undefined };
+    mirror(message);
+    mirror(message);
+    expect(useStore.getState().agentConversations.get('host')?.messages).toEqual([message]);
+  });
+
+  it('preserves no-options legacy memory and author-only options without prose deduplication', () => {
+    const store = useStore.getState();
+    store.addAgentMessage('host', 'agent', 'same words');
+    store.addAgentMessage('host', 'agent', 'same words');
+    store.addAgentMessage('host', 'agent', 'same words', { authorId: 'crew', callsign: 'Crew' });
+    const messages = useStore.getState().agentConversations.get('host')!.messages;
+    expect(messages).toHaveLength(3);
+    expect(new Set(messages.map(message => message.id)).size).toBe(3);
+    for (const message of messages) {
+      expect(message.id).not.toMatch(/^transient:/);
+      expect(message.threadId).toBeUndefined();
+      expect(message.timestamp).toBeGreaterThan(0);
+    }
+    expect(Object.keys(messages[0]).sort()).toEqual(['id', 'role', 'text', 'timestamp']);
+    expect(messages[2]).toMatchObject({ authorId: 'crew', callsign: 'Crew' });
+    expect(useStore.getState().agentConversations.get('host')?.unreadCount).toBe(3);
+  });
+});
+
+describe('thread reply reconciliation', () => {
+  const row = (id: string, timestamp = 42): AgentProfileMessage => ({
+    id, threadId: 't1', role: 'agent', authorId: 'a1', text: 'same words', timestamp,
+  });
+
+  it('seeds an empty thread and reconciles repeated identity without moving timestamp ties', () => {
+    const store = useStore.getState();
+    expect(store.reconcileThreadMessage('t1', row('first'))).toBe(true);
+    expect(store.reconcileThreadMessage('t1', row('second'))).toBe(true);
+    expect(store.reconcileThreadMessage('t1', { ...row('first'), text: 'canonical update' })).toBe(false);
+    expect(useStore.getState().threadMessages.get('t1')).toEqual([
+      { ...row('first'), text: 'canonical update' }, row('second'),
+    ]);
+  });
+
+  it('deduplicates before the cap and does not let an older receipt evict a newer row', () => {
+    const store = useStore.getState();
+    const messages = Array.from({ length: 200 }, (_, index) => row(`row-${index}`, index + 1));
+    store.setThreadMessages('t1', [...messages, messages[199]]);
+    expect(store.reconcileThreadMessage('t1', messages[199])).toBe(false);
+    expect(useStore.getState().threadMessages.get('t1')).toEqual(messages);
+    expect(store.reconcileThreadMessage('t1', row('old', 0))).toBe(false);
+    expect(useStore.getState().threadMessages.get('t1')).toEqual(messages);
+  });
+
+  it('orders delayed receipts chronologically without changing timestamps or another room', () => {
+    const store = useStore.getState();
+    store.setThreadMessages('t2', [mkMsg('unrelated')]);
+    store.reconcileThreadMessage('t1', row('new', 20));
+    store.reconcileThreadMessage('t1', row('older', 10));
+    expect(useStore.getState().threadMessages.get('t1')).toEqual([row('older', 10), row('new', 20)]);
+    expect(useStore.getState().threadMessages.get('t2')).toEqual([mkMsg('unrelated')]);
+  });
+
+  it.each([
+    { id: '' }, { threadId: 'other' }, { text: '' }, { authorId: '' },
+    { timestamp: NaN }, { timestamp: -1 },
+  ])('rejects invalid rows without mutation: %j', (invalid) => {
+    const before = useStore.getState().threadMessages;
+    expect(useStore.getState().reconcileThreadMessage('t1', { ...row('reply'), ...invalid })).toBe(false);
+    expect(useStore.getState().threadMessages).toBe(before);
+  });
+
+  it('rejects an empty thread identity', () => {
+    expect(useStore.getState().reconcileThreadMessage('', { ...row('reply'), threadId: '' })).toBe(false);
+    expect(useStore.getState().threadMessages.size).toBe(0);
+  });
+
+  it('correlates only the exact Captain token and retains distinct identical sends', () => {
+    const store = useStore.getState();
+    const captain = (id: string, token: unknown, optimistic = true): AgentProfileMessage => ({
+      id, threadId: 't1', role: 'user', authorId: 'captain', text: 'same words',
+      timestamp: 42, optimistic, metadata: { client_message_id: token },
+    });
+    store.setThreadMessages('t1', [captain('pending-one', 'one'), captain('pending-two', 'two')]);
+    store.reconcileThreadMessage('t1', captain('canonical-one', 'one', false));
+    expect(useStore.getState().threadMessages.get('t1')?.map(message => message.id))
+      .toEqual(['pending-two', 'canonical-one']);
+    store.reconcileThreadMessage('t1', captain('canonical-two', 'two', false));
+    expect(useStore.getState().threadMessages.get('t1')?.map(message => message.id))
+      .toEqual(['canonical-one', 'canonical-two']);
+  });
+
+  it.each([null, undefined, '', ' ', 12, {}])('does not correlate invalid tokens: %j', (token) => {
+    const pending: AgentProfileMessage = {
+      ...row('pending'), role: 'user', authorId: 'captain', optimistic: true,
+      metadata: { client_message_id: token },
+    };
+    useStore.getState().setThreadMessages('t1', [pending]);
+    useStore.getState().reconcileThreadMessage('t1', { ...pending, id: 'canonical', optimistic: false });
+    expect(useStore.getState().threadMessages.get('t1')).toHaveLength(2);
+  });
+
+  it('does not correlate another role, author, or room', () => {
+    const pending: AgentProfileMessage = {
+      ...row('pending'), role: 'user', authorId: 'captain', optimistic: true,
+      metadata: { client_message_id: 'token' },
+    };
+    const store = useStore.getState();
+    store.setThreadMessages('t1', [pending]);
+    store.reconcileThreadMessage('t1', { ...pending, id: 'agent', optimistic: false, role: 'agent' });
+    store.reconcileThreadMessage('t1', { ...pending, id: 'other-author', optimistic: false, authorId: 'other' });
+    store.reconcileThreadMessage('t2', { ...pending, id: 'other-room', optimistic: false, threadId: 't2' });
+    expect(useStore.getState().threadMessages.get('t1')?.[0]).toEqual(pending);
+    expect(useStore.getState().threadMessages.get('t1')).toHaveLength(3);
+  });
+
+  it('prefers authoritative snapshot collisions while retaining new local identities in tie order', () => {
+    const store = useStore.getState();
+    store.setThreadMessages('t1', [row('removed'), row('first'), row('second')]);
+    const baseline = useStore.getState().threadMessages.get('t1')!;
+    store.reconcileThreadMessage('t1', { ...row('first'), text: 'new receipt' });
+    store.reconcileThreadMessage('t1', row('new'));
+    expect(useStore.getState().threadMessages.get('t1')?.find(message => message.id === 'first')?.text)
+      .toBe('new receipt');
+    const canonical = { ...row('first'), text: 'server normalized body', metadata: { canonical: true } };
+    store.setThreadMessages('t1', [row('second'), canonical], baseline);
+    expect(useStore.getState().threadMessages.get('t1')).toEqual([
+      row('second'), canonical, row('new'),
+    ]);
+  });
+
+  it('does not resurrect evicted rows from a launch baseline or union subsequent snapshots', () => {
+    const store = useStore.getState();
+    const messages = Array.from({ length: 200 }, (_, index) => row(`row-${index}`, index + 1));
+    store.setThreadMessages('t1', messages);
+    const baseline = useStore.getState().threadMessages.get('t1')!;
+    store.reconcileThreadMessage('t1', row('new', 201));
+    store.setThreadMessages('t1', messages, baseline);
+    expect(useStore.getState().threadMessages.get('t1')).toEqual([...messages.slice(1), row('new', 201)]);
+    store.reconcileThreadMessage('t1', row('old', 0));
+    expect(useStore.getState().threadMessages.get('t1')).toHaveLength(200);
+    const nextBaseline = useStore.getState().threadMessages.get('t1')!;
+    store.setThreadMessages('t1', [], nextBaseline);
+    expect(useStore.getState().threadMessages.get('t1')).toEqual([]);
+  });
+
+  it('preserves arrivals into an initially empty snapshot', () => {
+    useStore.getState().reconcileThreadMessage('t1', row('new'));
+    useStore.getState().setThreadMessages('t1', [], []);
+    expect(useStore.getState().threadMessages.get('t1')).toEqual([row('new')]);
+  });
+
+  it.each(['solo', 'transient-group'])('retains identity-bearing arrivals without preserving uncorrelated legacy mirrors: %s', (mode) => {
+    const store = useStore.getState();
+    const canonical = row('saved-reply');
+    const legacy = mode === 'solo'
+      ? { id: 'local-reply', role: 'agent' as const, text: canonical.text, timestamp: 43 }
+      : { ...row('transient:local-reply', 43) };
+    store.appendThreadMessage('t1', legacy);
+    store.setThreadMessages('t1', [canonical]);
+    expect(useStore.getState().threadMessages.get('t1')).toEqual([canonical]);
+    store.setThreadMessages('t1', []);
+    const baseline = useStore.getState().threadMessages.get('t1')!;
+    store.appendThreadMessage('t1', legacy);
+    store.reconcileThreadMessage('t1', row('new-canonical', 44));
+    expect(useStore.getState().threadMessages.get('t1')?.some(message => message.id === legacy.id)).toBe(true);
+    store.setThreadMessages('t1', [canonical], baseline);
+    expect(useStore.getState().threadMessages.get('t1')).toEqual([canonical, row('new-canonical', 44)]);
+  });
+
+  it('rejects null and invalid boundary inputs without mutation', () => {
+    const store = useStore.getState();
+    const before = store.threadMessages;
+    expect(store.reconcileThreadMessage(null as unknown as string, row('new'))).toBe(false);
+    expect(store.reconcileThreadMessage('t1', null as unknown as AgentProfileMessage)).toBe(false);
+    store.setThreadMessages('t1', null as unknown as AgentProfileMessage[]);
+    store.setThreadMessages('', []);
+    store.setThreadMessages('t1', [], null as unknown as AgentProfileMessage[]);
+    expect(useStore.getState().threadMessages).toBe(before);
+  });
 });
 
 describe('AD-938 threadMessages store slice', () => {

--- a/ui/src/store/types.ts
+++ b/ui/src/store/types.ts
@@ -389,6 +389,9 @@ export interface NotificationView {
 
 export interface AgentProfileMessage {
   id: string;
+  threadId?: string;
+  metadata?: Record<string, unknown> | null;
+  optimistic?: boolean;
   // AD-809: 'system' added so the /personality slash-command reply
   // can render with distinct styling (subtle dim italic) — see
   // ProfileChatTab message render.

--- a/ui/src/store/useStore.ts
+++ b/ui/src/store/useStore.ts
@@ -611,7 +611,7 @@ export interface HXIState {
     agentId: string,
     role: 'user' | 'agent' | 'system',
     text: string,
-    opts?: { authorId?: string; callsign?: string },
+    opts?: { authorId?: string; callsign?: string; message?: AgentProfileMessage },
   ) => void;
   markAgentRead: (agentId: string) => void;
   setProfilePanelPos: (pos: { x: number; y: number }) => void;
@@ -637,8 +637,9 @@ export interface HXIState {
   // AD-938: thread-keyed display transcript actions (mirror the chatThreads Map
   // pattern). ``setThreadMessages`` replaces a thread's list (load-on-open);
   // ``appendThreadMessage`` adds one message (send-reconcile), capped to 200.
-  setThreadMessages: (threadId: string, msgs: AgentProfileMessage[]) => void;
+  setThreadMessages: (threadId: string, msgs: AgentProfileMessage[], baseline?: readonly AgentProfileMessage[]) => void;
   appendThreadMessage: (threadId: string, msg: AgentProfileMessage) => void;
+  reconcileThreadMessage: (threadId: string, msg: AgentProfileMessage) => boolean;
   setActiveThread: (threadId: string | null) => void;
   hydrateChatThreads: (threads: AD791aChatThreadView[]) => void;
   // AD-793 (Wave 196): project state actions.
@@ -1878,6 +1879,20 @@ export const useStore = create<HXIState>((set, get) => ({
     set({ activeProfileAgent: null, activeProfileThreadId: null, agentConversations: convs, notificationNavigation: null });
   },
   addAgentMessage: (agentId, role, text, opts) => {
+    const receipt = opts?.message;
+    if (receipt !== undefined && (!receipt
+      || typeof agentId !== 'string' || !agentId.trim()
+      || [receipt.id, receipt.threadId, receipt.authorId].some((value) => (
+        typeof value !== 'string' || !value.length || value.length > 128
+        || value.trim() !== value || /[\u0000-\u001f\u007f]/.test(value)
+      ))
+      || receipt.role !== 'agent' || receipt.role !== role
+      || typeof receipt.text !== 'string' || !receipt.text.trim() || receipt.text !== text
+      || typeof receipt.timestamp !== 'number' || !Number.isFinite(receipt.timestamp) || receipt.timestamp < 0
+      || receipt.optimistic
+      || (opts?.authorId !== undefined && opts.authorId !== receipt.authorId)
+      || (receipt.metadata !== undefined && receipt.metadata !== null
+        && (typeof receipt.metadata !== 'object' || Array.isArray(receipt.metadata))))) return;
     const convs = new Map(get().agentConversations);
     const existing = convs.get(agentId) || {
       agentId,
@@ -1885,7 +1900,10 @@ export const useStore = create<HXIState>((set, get) => ({
       unreadCount: 0,
       minimized: false,
     };
-    const msg: AgentProfileMessage = {
+    if (receipt && existing.messages.some((message) => (
+      message.threadId === receipt.threadId && message.id === receipt.id
+    ))) return;
+    const msg: AgentProfileMessage = receipt ? { ...receipt } : {
       id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
       role,
       text,
@@ -1996,10 +2014,36 @@ export const useStore = create<HXIState>((set, get) => ({
       set({ liveRailOwner: null });
     }
   },
-  // AD-938: replace a thread's display transcript (load-on-open).
-  setThreadMessages: (threadId, msgs) => {
+  // Canonical arrivals survive in-flight snapshots; legacy mirrors and transient rows do not.
+  setThreadMessages: (threadId, msgs, baseline) => {
+    if (typeof threadId !== 'string' || !threadId.trim() || !Array.isArray(msgs)
+      || (baseline !== undefined && !Array.isArray(baseline))) return;
+    const existing = get().threadMessages.get(threadId) ?? [];
+    const accepted = baseline === undefined ? [] : existing.filter(
+      (message) => message.threadId === threadId && !message.id.startsWith('transient:')
+        && !baseline.includes(message),
+    );
+    const byId = new Map(msgs.filter((message) => message && message.id
+      && (!message.threadId || message.threadId === threadId)
+      && typeof message.text === 'string' && Number.isFinite(message.timestamp)
+      && message.timestamp >= 0 && ['user', 'agent', 'system'].includes(message.role))
+      .map((message) => [message.id, message]));
+    for (const message of accepted) {
+      if (!byId.has(message.id)) byId.set(message.id, message);
+    }
+    const canonicalTokens = new Set([...byId.values()].filter((message) => (
+      !message.optimistic && message.threadId === threadId
+      && message.role === 'user' && message.authorId === 'captain'
+      && typeof message.metadata?.client_message_id === 'string'
+      && message.metadata.client_message_id.trim().length > 0
+    )).map((message) => message.metadata!.client_message_id));
+    const messages = [...byId.values()].filter((message) => !(
+      message.optimistic && message.threadId === threadId
+      && message.role === 'user' && message.authorId === 'captain'
+      && canonicalTokens.has(message.metadata?.client_message_id)
+    )).sort((left, right) => left.timestamp - right.timestamp).slice(-200);
     const next = new Map(get().threadMessages);
-    next.set(threadId, msgs);
+    next.set(threadId, messages);
     set({ threadMessages: next });
   },
   // AD-938: append one message to a thread's display transcript (send-reconcile),
@@ -2009,6 +2053,19 @@ export const useStore = create<HXIState>((set, get) => ({
     const existing = next.get(threadId) ?? [];
     next.set(threadId, [...existing.slice(-199), msg]);
     set({ threadMessages: next });
+  },
+  reconcileThreadMessage: (threadId: string, msg: AgentProfileMessage): boolean => {
+    if (typeof threadId !== 'string' || !threadId.trim() || !msg
+      || typeof msg.id !== 'string' || !msg.id.trim() || msg.threadId !== threadId
+      || typeof msg.text !== 'string' || !msg.text.trim()
+      || !Number.isFinite(msg.timestamp) || msg.timestamp < 0
+      || !['user', 'agent', 'system'].includes(msg.role)
+      || (msg.role === 'agent' && (typeof msg.authorId !== 'string' || !msg.authorId.trim()))) return false;
+    const existing = get().threadMessages.get(threadId) ?? [];
+    const alreadyPresent = existing.some((message) => message.id === msg.id);
+    get().setThreadMessages(threadId, [...existing, msg]);
+    const messages = get().threadMessages.get(threadId) ?? [];
+    return !alreadyPresent && messages.some((message) => message.id === msg.id);
   },
   setActiveThread: (threadId) => set({ activeThreadId: threadId }),
   hydrateChatThreads: (threads) => {


### PR DESCRIPTION
Fixes #1372

## Changes
- Return exact persisted message receipts for group replies and reconcile HTTP, live refresh, hydration, replay and optimistic Captain rows by thread/message identity.
- Preserve canonical timestamps, distinct same-text messages, bounded transcripts, room ownership and per-agent conversation memory.
- Keep group text silent and meeting speech attributed once per message; preserve accepted replies through mute, unmount and scope changes.
- Update existing Python consumer assertions to verify the added receipt without weakening trust, convergence, write-effect or episodic checks.

## Verification
- Canonical committed-HEAD gate: 30,016 passed, 30 skipped, 7 subtests passed.
- Full UI: 2,794 passed, 1 skipped; TypeScript and production build passed.
- Browser: all 13 group-identity and existing notification-navigation cases passed at 900px and 1440px.
- Focused Python consumer suite: 223 passed; backend identity suite: 23 passed.
- Independent precommit and formal different-family reviews passed; the formal handoff chain and canonical receipt were verified against 4ee0b02e82fb0c89c29a848105ba304b97ea37b6.

The initial full gate exposed 82 obsolete strict reply-shape/semantic assertions. The bounded test repair preserved their behavioral checks, added full persisted-row equality, and the fresh full gate passed. No production data, dependencies or existing notification fixtures were changed.