### PR TITLE
fix(hxi): present equivalent redundant results once (#1378)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,8 +62,22 @@ jobs:
     # regressions.
     timeout-minutes: 15
 
+    env:
+      PROBOS_EMBEDDINGS: local
+      PROBOS_TEST_PYTHON: ${{ github.workspace }}/.venv/bin/python
+
     steps:
       - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Install backend test dependencies
+        run: uv sync --group dev --extra discovery --extra browser
 
       - uses: actions/setup-node@v7
         with:

--- a/src/probos/utils/response_formatter.py
+++ b/src/probos/utils/response_formatter.py
@@ -6,7 +6,11 @@ Extracted from api.py to be reusable across REST API, Discord, Slack, etc.
 from __future__ import annotations
 
 import logging
+import math
+from datetime import datetime, timezone
 from typing import Any
+
+from probos.types import IntentResult
 
 logger = logging.getLogger(__name__)
 
@@ -59,7 +63,10 @@ def _extract_from_results(results_dict: dict[str, Any]) -> str:
             # Normal intent results — list of IntentResult dataclasses
             intent_results = node_result.get("results")
             if isinstance(intent_results, list):
+                node_start = len(parts)
+                contributions: list[tuple[Any, str | None]] = []
                 for r in intent_results:
+                    contribution_start = len(parts)
                     if hasattr(r, "result") and r.result is not None:
                         val = r.result
                         if isinstance(val, dict) and "stdout" in val:
@@ -75,8 +82,138 @@ def _extract_from_results(results_dict: dict[str, Any]) -> str:
                         out = r.get("output") or r.get("result") or r.get("text")
                         if out:
                             parts.append(str(out))
+                    contributions.append((
+                        r, parts[-1] if len(parts) > contribution_start else None,
+                    ))
+                parts[node_start:] = _equivalent_node_parts(
+                    contributions, parts[node_start:],
+                )
             elif "output" in node_result:
                 parts.append(str(node_result["output"]))
         elif isinstance(node_result, str) and node_result:
             parts.append(node_result)
     return "\n".join(parts)
+
+
+_RESULT_FIELDS = frozenset({
+    "intent_id", "agent_id", "success", "result", "error", "confidence",
+    "timestamp", "metadata",
+})
+
+
+class _IneligibleNode(Exception):
+    pass
+
+
+class _EquivalenceBudget:
+    def __init__(self) -> None:
+        self.values = 0
+        self.characters = 0
+        self.active: set[int] = set()
+
+    def _consume(self, value: Any, depth: int = 0) -> None:
+        self.values += 1
+        if depth > 32 or self.values > 4096:
+            raise _IneligibleNode
+        if type(value) is str:
+            self.characters += len(value)
+            if len(value) > 65536 or self.characters > 1048576:
+                raise _IneligibleNode
+        elif type(value) is int and value.bit_length() > 4096:
+            raise _IneligibleNode
+
+    def _freeze(self, value: Any, depth: int = 0) -> tuple[Any, ...]:
+        self._consume(value, depth)
+        value_type = type(value)
+        if any(value_type is scalar_type for scalar_type in (type(None), bool, int, str)):
+            return (value_type, value)
+        if value_type is float:
+            if not math.isfinite(value):
+                raise _IneligibleNode
+            return (float, value.hex())
+        if not any(value_type is container_type for container_type in (list, tuple, dict)) or id(value) in self.active:
+            raise _IneligibleNode
+        self.active.add(id(value))
+        try:
+            if value_type is dict:
+                entries = []
+                for key, member in value.items():
+                    if type(key) is not str:
+                        raise _IneligibleNode
+                    entries.append((
+                        self._freeze(key, depth + 1),
+                        self._freeze(member, depth + 1),
+                    ))
+                return (dict, tuple(entries))
+            return (value_type, tuple(
+                self._freeze(member, depth + 1) for member in value
+            ))
+        finally:
+            self.active.remove(id(value))
+
+    def _candidate(self, record: Any, text: str | None) -> tuple[Any, ...]:
+        self._consume(record)
+        if type(record) is IntentResult:
+            fields = vars(record)
+        elif type(record) is dict:
+            fields = record
+        else:
+            raise _IneligibleNode
+        if (type(fields) is not dict or len(fields) != 8
+                or any(type(key) is not str for key in fields)
+                or fields.keys() != _RESULT_FIELDS):
+            raise _IneligibleNode
+        for key in fields:
+            self._freeze(key)
+        if (type(text) is not str or not text
+                or fields["success"] is not True or fields["error"] is not None
+                or not any(type(fields["confidence"]) is number_type for number_type in (int, float))
+                or type(fields["metadata"]) is not dict):
+            raise _IneligibleNode
+        for name in ("intent_id", "agent_id"):
+            identity = fields[name]
+            if type(identity) is not str:
+                raise _IneligibleNode
+            self._freeze(identity)
+            if not identity.strip():
+                raise _IneligibleNode
+        self._freeze(fields["success"])
+        self._freeze(fields["error"])
+        confidence = self._freeze(fields["confidence"])
+        timestamp = fields["timestamp"]
+        self._consume(timestamp)
+        if type(timestamp) is str:
+            try:
+                timestamp = datetime.fromisoformat(timestamp)
+            except ValueError:
+                raise _IneligibleNode from None
+        if type(timestamp) is not datetime or type(timestamp.tzinfo) is not timezone:
+            raise _IneligibleNode
+        result = self._freeze(fields["result"])
+        metadata = self._freeze(fields["metadata"])
+        self._consume(text)
+        return (fields["intent_id"], confidence, result, metadata, text)
+
+    def select(self, contributions: list[tuple[Any, str | None]]) -> list[str]:
+        groups: dict[tuple[Any, ...], list[tuple[int, str]]] = {}
+        for index, (record, text) in enumerate(contributions):
+            key = self._candidate(record, text)
+            agent_id = record.agent_id if type(record) is IntentResult else record["agent_id"]
+            groups.setdefault(key, []).append((index, agent_id))
+        omitted: set[int] = set()
+        for group in groups.values():
+            if len({agent_id for _, agent_id in group}) == len(group):
+                omitted.update(index for index, _ in group[1:])
+        return [
+            text for index, (_, text) in enumerate(contributions)
+            if index not in omitted and text is not None
+        ]
+
+
+def _equivalent_node_parts(
+    contributions: list[tuple[Any, str | None]], original: list[str],
+) -> list[str]:
+    try:
+        return _EquivalenceBudget().select(contributions)
+    except _IneligibleNode:
+        return original

--- a/tests/test_channel_base.py
+++ b/tests/test_channel_base.py
@@ -1,6 +1,7 @@
 """Tests for channel adapter base classes and response formatter."""
 
 import asyncio
+import copy
 from typing import Any
 from dataclasses import dataclass
 
@@ -16,6 +17,7 @@ from probos.utils.response_formatter import extract_response_text
 from probos.cognitive.llm_client import MockLLMClient
 from probos.config import SystemConfig
 from probos.runtime import ProbOSRuntime
+from probos.types import IntentResult
 
 
 # ---------------------------------------------------------------------------
@@ -23,6 +25,39 @@ from probos.runtime import ProbOSRuntime
 # ---------------------------------------------------------------------------
 
 class TestExtractResponseText:
+    @pytest.mark.parametrize("field", ["metadata", "confidence"])
+    def test_unsupported_metadata_never_invokes_metaclass_equality(self, field: str) -> None:
+        class _EqualityGuard(type):
+            def __eq__(self, other: object) -> bool:
+                raise AssertionError("Equivalence must not invoke metaclass equality")
+
+        class _Unsupported(metaclass=_EqualityGuard):
+            pass
+
+        changes = {field: {"unsupported": _Unsupported()} if field == "metadata" else _Unsupported()}
+        assert self._format(
+            self._record(**changes), self._record("b", **changes),
+        ) == "391\n391"
+
+    @staticmethod
+    def _record(agent_id: str = "a", **changes: Any) -> Any:
+        from datetime import datetime, timezone
+
+        from probos.types import IntentResult
+
+        fields = {
+            "intent_id": "i", "agent_id": agent_id, "success": True,
+            "result": "391", "error": None, "confidence": 0.9,
+            "timestamp": datetime(2026, 9, 12, tzinfo=timezone.utc),
+            "metadata": {},
+        }
+        fields.update(changes)
+        return IntentResult(**fields)
+
+    @staticmethod
+    def _format(*records: Any) -> str:
+        return extract_response_text({"results": {"node": {"results": list(records)}}})
+
     def test_none_result(self):
         assert extract_response_text(None) == "(Processing failed)"
 
@@ -83,6 +118,256 @@ class TestExtractResponseText:
         result = {"response": "", "results": {}}
         text = extract_response_text(result)
         assert len(text) > 0  # Should return a fallback message
+
+    @pytest.mark.parametrize("representation", ["dataclass", "dict", "mixed"])
+    def test_equivalent_distinct_agents_preserve_evidence(self, representation: str) -> None:
+        from copy import deepcopy
+        from datetime import datetime, timedelta, timezone
+
+        records = [self._record(), self._record("b")]
+        records[1].timestamp = datetime(2026, 9, 13, tzinfo=timezone(timedelta(hours=2)))
+        if representation == "dict":
+            records = [dict(vars(record)) for record in records]
+        elif representation == "mixed":
+            records[1] = dict(vars(records[1]))
+        if representation != "dataclass":
+            records[1]["timestamp"] = "2026-09-13T12:00:00+02:00"
+        envelope = {"results": {"node": {"results": records}}}
+        snapshot = deepcopy(envelope)
+        identities = [id(record) for record in records]
+
+        assert len(records) == 2
+        assert extract_response_text(envelope) == "391"
+        assert extract_response_text(envelope) == "391"
+        assert envelope == snapshot
+        assert envelope["results"]["node"]["results"] is records
+        assert [id(record) for record in records] == identities
+
+    @pytest.mark.parametrize("agents,expected", [
+        (["a", "b"], "391"),
+        (["a", "a"], "391\n391"),
+        (["a", "b", "a"], "391\n391\n391"),
+        (["a", " a"], "391"),
+    ])
+    def test_agent_multiplicity(self, agents: list[str], expected: str) -> None:
+        assert self._format(*(self._record(agent) for agent in agents)) == expected
+
+    @pytest.mark.parametrize("repeat", [False, True])
+    def test_interleaved_groups_keep_original_order(self, repeat: bool) -> None:
+        records = [
+            self._record(), self._record("c", result="392"),
+            self._record("a" if repeat else "b"), self._record("d", result="392"),
+        ]
+        assert self._format(*records) == ("391\n392\n391" if repeat else "391\n392")
+
+    @pytest.mark.parametrize("changes", [
+        {"intent_id": "other"}, {"intent_id": " i"},
+        {"confidence": 0.8}, {"metadata": {"source": "other"}},
+        {"result": 391}, {"result": "392"},
+    ])
+    def test_differing_evidence_is_not_suppressed(self, changes: dict[str, Any]) -> None:
+        first, second = self._record(), self._record("b", **changes)
+        assert self._format(first, second) == f"{first.result}\n{second.result}"
+
+    @pytest.mark.parametrize("field", ["result", "metadata", "confidence"])
+    @pytest.mark.parametrize("left,right", [(True, 1), (1, 1.0), (0.0, -0.0)])
+    def test_typed_scalar_differences(self, field: str, left: Any, right: Any) -> None:
+        if field in ("result", "metadata"):
+            left = {"stdout": "391", "hidden": left}
+            right = {"stdout": "391", "hidden": right}
+        first, second = self._record(**{field: left}), self._record("b", **{field: right})
+        assert self._format(first, second) == "391\n391"
+
+    @pytest.mark.parametrize("field", ["result", "metadata"])
+    @pytest.mark.parametrize("left,right", [
+        ([1, 2], (1, 2)), ([1, 2], [2, 1]),
+        ({"first": 1, "second": 2}, {"second": 2, "first": 1}),
+        ({"stderr": ""}, {"stderr": None}),
+        ({"exit_code": 0}, {"exit_code": 1}),
+        ({"source": "a"}, {"source": "b"}),
+    ])
+    def test_hidden_structure_differences(self, field: str, left: Any, right: Any) -> None:
+        first = self._record(**{field: {"stdout": "391", "hidden": left}})
+        second = self._record("b", **{field: {"stdout": "391", "hidden": right}})
+        assert self._format(first, second) == "391\n391"
+
+    @pytest.mark.parametrize("value", [None, False, 1, 1.0, -0.0, "", [], (), {}, [None, {"x": (True, 1)}]])
+    def test_supported_hidden_values_can_match(self, value: Any) -> None:
+        payload = {"stdout": "391", "hidden": value}
+        assert self._format(self._record(result=payload), self._record("b", result=payload)) == "391"
+
+    @pytest.mark.parametrize("changes", [
+        {"success": False}, {"success": 1}, {"error": "failed"}, {"error": ""},
+        {"agent_id": ""}, {"agent_id": " \t"}, {"agent_id": None},
+        {"intent_id": ""}, {"intent_id": " \t"}, {"intent_id": 1},
+        {"confidence": True}, {"confidence": None}, {"confidence": float("inf")},
+        {"confidence": float("nan")}, {"metadata": None}, {"metadata": []},
+        {"timestamp": None}, {"timestamp": 0}, {"timestamp": "invalid"},
+        {"timestamp": "2026-09-12"}, {"timestamp": "2026-09-12T12:00:00"},
+    ])
+    def test_late_ineligible_record_preserves_whole_node(self, changes: dict[str, Any]) -> None:
+        late = self._record(**changes)
+        assert self._format(self._record(), self._record("b"), late) == "391\n391\n391"
+
+    @pytest.mark.parametrize("kind", ["missing", "extra", "attribute", "dict-subclass", "record-subclass", "duck", "key-subclass"])
+    def test_nonexact_records_preserve_whole_node(self, kind: str) -> None:
+        from types import SimpleNamespace
+
+        from probos.types import IntentResult
+
+        class RecordSubclass(IntentResult):
+            pass
+
+        class DictSubclass(dict):
+            pass
+
+        class StringSubclass(str):
+            pass
+
+        late = self._record("c")
+        fields = dict(vars(late))
+        if kind == "missing":
+            fields.pop("metadata")
+            late = fields
+        elif kind == "extra":
+            late = {**fields, "extra": None}
+        elif kind == "attribute":
+            late.extra = None
+        elif kind == "dict-subclass":
+            late = DictSubclass(fields)
+        elif kind == "record-subclass":
+            late = RecordSubclass(**fields)
+        elif kind == "duck":
+            late = SimpleNamespace(**fields)
+        else:
+            late = {StringSubclass(key): value for key, value in fields.items()}
+        assert self._format(self._record(), self._record("b"), late) == "391\n391\n391"
+
+    @pytest.mark.parametrize("kind", ["naive", "datetime-subclass", "custom-tz", "string-subclass"])
+    def test_timestamp_types_are_conservative(self, kind: str) -> None:
+        from datetime import datetime, timedelta, timezone, tzinfo
+
+        class DatetimeSubclass(datetime):
+            pass
+
+        class StringSubclass(str):
+            pass
+
+        class CustomTimezone(tzinfo):
+            def utcoffset(self, value: Any) -> timedelta:
+                return timedelta(0)
+
+        timestamp = {
+            "naive": datetime(2026, 9, 12),
+            "datetime-subclass": DatetimeSubclass(2026, 9, 12, tzinfo=timezone.utc),
+            "custom-tz": datetime(2026, 9, 12, tzinfo=CustomTimezone()),
+            "string-subclass": StringSubclass("2026-09-12T00:00:00Z"),
+        }[kind]
+        assert self._format(self._record(), self._record("b", timestamp=timestamp)) == "391\n391"
+
+    @pytest.mark.parametrize("field", ["result", "metadata"])
+    @pytest.mark.parametrize("kind", ["cycle", "nan", "inf", "set", "bytes", "object", "list-subclass", "int-subclass", "nonstring-key"])
+    def test_unsupported_nested_values_preserve_whole_node(self, field: str, kind: str) -> None:
+        class ListSubclass(list):
+            pass
+
+        class IntSubclass(int):
+            pass
+
+        cycle: list[Any] = []
+        cycle.append(cycle)
+        value = {
+            "cycle": cycle, "nan": float("nan"), "inf": float("-inf"),
+            "set": {1}, "bytes": b"391", "object": object(),
+            "list-subclass": ListSubclass([1]), "int-subclass": IntSubclass(1),
+            "nonstring-key": {1: "value"},
+        }[kind]
+        late = self._record("c", **{field: {"stdout": "391", "hidden": value}})
+        assert self._format(self._record(), self._record("b"), late) == "391\n391\n391"
+
+    @pytest.mark.parametrize("representation", ["dataclass", "dict"])
+    @pytest.mark.parametrize("value", [None, "", False, 0, [], {}])
+    def test_empty_payload_preserves_legacy_rendering(self, representation: str, value: Any) -> None:
+        late = self._record("c", result=value)
+        if representation == "dict":
+            late = dict(vars(late))
+        expected = "391\n391"
+        if representation == "dataclass" and value is not None:
+            rendered = str(value)
+            expected = "391\n" + rendered if rendered else expected + "\n"
+        assert self._format(self._record(), self._record("b"), late) == expected
+
+    @pytest.mark.parametrize("budget", ["depth", "values", "string", "characters", "integer"])
+    @pytest.mark.parametrize("exceeded", [False, True])
+    def test_equivalence_budget_boundaries(self, budget: str, exceeded: bool) -> None:
+        if budget == "depth":
+            hidden: Any = None
+            for _ in range(31 + int(exceeded)):
+                hidden = [hidden]
+        elif budget == "values":
+            hidden = [None] * (2026 + int(exceeded))
+        elif budget == "string":
+            hidden = "x" * (65536 + int(exceeded))
+        elif budget == "characters":
+            hidden = ["x" * 65536] * 7 + ["x" * (65454 + int(exceeded))]
+        else:
+            hidden = 1 << (4095 + int(exceeded))
+        payload = {"stdout": "391", "hidden": hidden}
+        first, second = self._record(result=payload), self._record("b", result=payload)
+        assert first.result is second.result
+        assert self._format(first, second) == ("391\n391" if exceeded else "391")
+        assert first.result is payload and second.result is payload
+
+    def test_existing_rendered_text_must_also_match(self) -> None:
+        first = self._record(result={"stdout": "391"})
+        second = dict(vars(self._record("b", result={"stdout": "391"})))
+        assert self._format(first, second) == "391\n{'stdout': '391'}"
+
+    def test_stdout_stderr_rendering_is_unchanged(self) -> None:
+        payload = {"stdout": "391", "stderr": "warning", "exit_code": 0}
+        assert self._format(self._record(result=payload), self._record("b", result=payload)) == "391\nwarning"
+
+    def test_unsupported_payload_is_stringified_only_once(self) -> None:
+        class RenderOnce:
+            def __init__(self) -> None:
+                self.calls = 0
+
+            def __str__(self) -> str:
+                self.calls += 1
+                assert self.calls == 1
+                return "391"
+
+        first, second = RenderOnce(), RenderOnce()
+        assert self._format(self._record(result=first), self._record("b", result=second)) == "391\n391"
+        assert first.calls == second.calls == 1
+
+    def test_independent_nodes_and_invocations_are_not_suppressed(self) -> None:
+        records = [self._record(), self._record("b")]
+        envelope = {"results": {"first": {"results": records}, "second": {"results": records}}}
+        assert extract_response_text(envelope) == "391\n391"
+        assert extract_response_text(envelope) == "391\n391"
+
+    @pytest.mark.parametrize("overrides,expected", [
+        ({"response": "direct", "reflection": "reflection", "correction": {"changes": "fixed"}}, "direct"),
+        ({"response": "", "reflection": "reflection", "correction": {"changes": "fixed"}}, "reflection"),
+        ({"reflection": "", "correction": {"changes": "fixed"}}, "fixed"),
+        ({"correction": {"other": True}}, "Correction applied"),
+        ({"correction": {"changes": ""}}, "391"),
+    ])
+    def test_precedence_over_equivalence(self, overrides: dict[str, Any], expected: str) -> None:
+        envelope = {"results": {"node": {"results": [self._record(), self._record("b")]}}}
+        envelope.update(overrides)
+        assert extract_response_text(envelope) == expected
+
+    def test_legacy_node_rendering_and_fallbacks(self) -> None:
+        envelope = {"results": {
+            "error": {"error": "failed", "results": [self._record(), self._record("b")]},
+            "output": {"output": "output"}, "text": "text",
+            "legacy": {"results": [{"output": "same"}, {"text": "same"}]},
+        }}
+        assert extract_response_text(envelope) == "Error: failed\noutput\ntext\nsame\nsame"
+        assert extract_response_text({}) == "(Processing failed)"
+        assert extract_response_text({"results": {"node": {"results": []}}}) == "(Empty response)"
 
 
 # ---------------------------------------------------------------------------
@@ -199,6 +484,53 @@ class TestChannelAdapterHandleMessage:
 # ---------------------------------------------------------------------------
 # BF-804: the pairing gate must not swallow a failed notification
 # ---------------------------------------------------------------------------
+
+
+class TestChannelResultPresentation:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("different_metadata", [False, True])
+    async def test_channel_retains_evidence_and_each_independent_message(
+        self, different_metadata: bool,
+    ) -> None:
+        from probos.channels import extract_response_text as exported_formatter
+
+        assert exported_formatter is extract_response_text
+        contributors = [
+            IntentResult(
+                intent_id="calculation", agent_id="calculator-first", success=True,
+                result="391", confidence=0.9,
+            ),
+            IntentResult(
+                intent_id="calculation", agent_id="calculator-second", success=True,
+                result="391", confidence=0.9,
+                metadata={"verification": "pending"} if different_metadata else {},
+            ),
+        ]
+        result = {"results": {"node": {"results": contributors, "result_count": 2}}}
+        original = copy.deepcopy(result)
+        histories: list[list[tuple[str, str]]] = []
+
+        class _ResultRuntime:
+            async def process_natural_language(
+                self, text: str, *, auto_selfmod: bool,
+                conversation_history: list[tuple[str, str]],
+            ) -> dict[str, Any]:
+                assert text == "calculate"
+                assert auto_selfmod is False
+                histories.append(list(conversation_history))
+                return result
+
+        adapter = _FakeAdapter(_ResultRuntime())
+        expected = "391\n391" if different_metadata else "391"
+        for occurrence in range(3):
+            message = ChannelMessage(text="calculate", channel_id="results", user_id="test-user")
+            response = await adapter.handle_message(message)
+            assert response == expected
+            await adapter.send_response(message.channel_id, response)
+            assert histories[occurrence] == [("user", "calculate"), ("assistant", expected)] * occurrence
+        assert adapter.sent == [("results", expected)] * 3
+        assert result == original
+        assert result["results"]["node"]["results"] is contributors
 
 
 class _PairingRuntime:

--- a/tests/test_hxi_chat_integration.py
+++ b/tests/test_hxi_chat_integration.py
@@ -4,12 +4,181 @@ These tests start a ProbOS runtime with MockLLMClient and test
 the /api/chat endpoint with common user queries to catch regressions.
 """
 
+import asyncio
+import contextlib
+import copy
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
 import pytest
 from httpx import AsyncClient, ASGITransport
+from pydantic import TypeAdapter
 
 from probos.api import create_app
 from probos.cognitive.llm_client import MockLLMClient
+from probos.config import SystemConfig
 from probos.runtime import ProbOSRuntime
+from probos.types import LLMRequest, LLMResponse, Priority
+from probos.utils import response_formatter
+
+
+_CALCULATOR_SCENARIOS = {
+    "calculate 17 multiplied by 23 and return only the answer": [("17*23", "391")],
+    "calculate 11 multiplied by 13 and return only the answer": [("11*13", "143")],
+    "calculate 17 multiplied by 23 twice as separate tasks": [
+        ("17*23", "391"), ("17*23", "391"),
+    ],
+}
+
+
+class _CalculatorDAGClient(MockLLMClient):
+    async def complete(
+        self, request: LLMRequest, *, priority: Priority = Priority.NORMAL,
+    ) -> LLMResponse:
+        message = request.prompt.lower().rsplit("user request: ", 1)[-1].strip()
+        expressions = _CALCULATOR_SCENARIOS.get(message)
+        if expressions is None:
+            return await super().complete(request, priority=priority)
+        content = json.dumps({
+            "intents": [
+                {
+                    "id": f"calculation-{index}",
+                    "intent": "calculate",
+                    "params": {"expression": expression},
+                    "depends_on": [],
+                    "use_consensus": False,
+                }
+                for index, (expression, _) in enumerate(expressions)
+            ],
+            "reflect": False,
+        })
+        return LLMResponse(
+            content=content, model="mock", tier=request.tier, request_id=request.id,
+        )
+
+
+async def _calculator_api_responses(
+    requests: list[dict[str, Any]], data_dir: Path,
+) -> list[dict[str, Any]]:
+    config = SystemConfig()
+    config.utility_agents.enabled = True
+    config.qa.enabled = False
+    runtime = ProbOSRuntime(
+        config=config, data_dir=data_dir, llm_client=_CalculatorDAGClient(),
+    )
+    extracted: list[dict[str, Any]] = []
+    original_formatter = response_formatter.extract_response_text
+
+    def capture_response(dag_result: dict[str, Any] | None) -> str:
+        assert dag_result is not None
+        assert not dag_result.get("response")
+        assert not dag_result.get("reflection")
+        original = copy.deepcopy(dag_result)
+        contribution_list = dag_result["results"]
+        references = {
+            node_id: tuple(node["results"])
+            for node_id, node in contribution_list.items()
+        }
+        response = original_formatter(dag_result)
+        assert dag_result == original
+        assert dag_result["results"] is contribution_list
+        for node_id, contributions in references.items():
+            assert all(
+                before is after
+                for before, after in zip(contributions, contribution_list[node_id]["results"])
+            )
+        extracted.append(TypeAdapter(dict[str, Any]).dump_python(contribution_list, mode="json"))
+        return response
+
+    responses: list[dict[str, Any]] = []
+    try:
+        await runtime.start()
+        app = create_app(runtime)
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as client:
+            with patch.object(response_formatter, "extract_response_text", capture_response):
+                previous_message = None
+                for request in requests:
+                    if request["message"] != previous_message:
+                        runtime.workflow_cache.clear()
+                    previous_message = request["message"]
+                    scenarios = _CALCULATOR_SCENARIOS[request["message"]]
+                    extraction_count = len(extracted)
+                    response = await client.post("/api/chat", json=request)
+                    assert response.status_code == 200, response.text
+                    payload = response.json()
+                    assert len(extracted) == extraction_count + 1
+                    assert payload["results"] == extracted[-1]
+                    assert payload["dag"]["source_text"] == request["message"]
+                    assert payload["dag"]["reflect"] is False
+                    assert len(payload["results"]) == len(scenarios)
+                    assert list(payload["results"]) == list(extracted[-1])
+                    for node, (_, answer) in zip(payload["results"].values(), scenarios):
+                        contributors = node["results"]
+                        assert len(contributors) >= 2
+                        assert node["result_count"] == len(contributors)
+                        assert len({item["agent_id"] for item in contributors}) == len(contributors)
+                        assert len({item["intent_id"] for item in contributors}) == 1
+                        for item in contributors:
+                            assert set(item) == {
+                                "intent_id", "agent_id", "success", "result", "error",
+                                "confidence", "timestamp", "metadata",
+                            }
+                            assert item["success"] is True
+                            assert item["result"] == answer
+                            assert item["error"] is None
+                    assert payload["response"] == "\n".join(answer for _, answer in scenarios)
+                    responses.append(payload)
+    finally:
+        await runtime.stop()
+    return responses
+
+
+@pytest.mark.asyncio
+async def test_global_calculators_preserve_contributors_and_independent_requests(tmp_path):
+    repeated, different, separate = _CALCULATOR_SCENARIOS
+    requests = [{"message": message} for message in (repeated, repeated, different, separate)]
+    responses = await _calculator_api_responses(requests, tmp_path / "calculator-data")
+    assert [response["response"] for response in responses] == ["391", "391", "143", "391\n391"]
+
+
+def _calculator_bridge() -> dict[str, Any]:
+    with contextlib.redirect_stdout(sys.stderr):
+        root = Path(__file__).resolve().parents[1]
+        assert Path(response_formatter.__file__).resolve().is_relative_to(root / "src")
+        request_bytes = sys.stdin.buffer.read(65537)
+        if len(request_bytes) > 65536:
+            raise ValueError("Calculator test request exceeds 65536 bytes")
+        requests = json.loads(request_bytes)
+        repeated, different, separate = _CALCULATOR_SCENARIOS
+        expected_messages = [repeated, repeated, different, separate, repeated]
+        if type(requests) is not list or len(requests) != len(expected_messages):
+            raise ValueError("Calculator bridge requires the complete five-request batch")
+        if any(
+            type(request) is not dict or request.get("message") != expected
+            for request, expected in zip(requests, expected_messages)
+        ):
+            raise ValueError("Unsupported or misordered calculator test scenario")
+        data_dir = Path(os.environ["PROBOS_DATA_DIR"]).resolve()
+        if (
+            data_dir.parent != Path(tempfile.gettempdir()).resolve()
+            or not data_dir.name.startswith("probos-calculator-test-")
+            or not data_dir.is_dir()
+        ):
+            raise ValueError("Calculator bridge requires a caller-owned temporary data directory")
+        responses = asyncio.run(_calculator_api_responses(requests, data_dir))
+    return {
+        "pairs": [
+            {"request": request, "envelope": response}
+            for request, response in zip(requests, responses)
+        ],
+    }
 
 
 @pytest.fixture

--- a/tests/test_task_scheduler.py
+++ b/tests/test_task_scheduler.py
@@ -3,13 +3,16 @@
 from __future__ import annotations
 
 import asyncio
+import copy
 import time
+from typing import Any
 
 import pytest
 
 pytestmark = pytest.mark.slow
 
 from probos.cognitive.task_scheduler import ScheduledTask, TaskScheduler
+from probos.types import IntentResult
 
 
 # ------------------------------------------------------------------
@@ -334,3 +337,65 @@ def test_get_stats():
     assert stats["total"] == 2
     assert stats["by_status"]["pending"] == 2
     assert stats["next_execute_in"] is not None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("second_result", "metadata", "direct_response", "expected"),
+    [
+        ("391", {}, None, "391"),
+        ("392", {}, None, "391\n392"),
+        ("391", {"verification": "pending"}, None, "391\n391"),
+        ("391", {}, "Synthesized answer", "Synthesized answer"),
+    ],
+)
+async def test_scheduled_result_presentation_retains_each_task_and_contributor(
+    second_result: str, metadata: dict[str, Any], direct_response: str | None, expected: str,
+) -> None:
+    contributors = [
+        IntentResult(
+            intent_id="calculation", agent_id="calculator-first", success=True,
+            result="391", confidence=0.9,
+        ),
+        IntentResult(
+            intent_id="calculation", agent_id="calculator-second", success=True,
+            result=second_result, confidence=0.9, metadata=metadata,
+        ),
+    ]
+    result = {
+        "response": direct_response,
+        "results": {"node": {"results": contributors, "result_count": 2}},
+    }
+    original = copy.deepcopy(result)
+
+    class _DeliveryAdapter(FakeAdapter):
+        def __init__(self) -> None:
+            super().__init__()
+            self.delivered = asyncio.Event()
+
+        async def send_response(self, channel_id: str, text: str, **kwargs: Any) -> None:
+            await super().send_response(channel_id, text, **kwargs)
+            if len(self.sent) == 2:
+                self.delivered.set()
+
+    adapter = _DeliveryAdapter()
+    runtime = FakeRuntime(response=result)
+    scheduler = TaskScheduler(
+        process_fn=runtime.process_natural_language, channel_adapters=[adapter],
+    )
+    tasks = [
+        scheduler.schedule("calculate", delay_seconds=0, channel_id=f"channel-{index}")
+        for index in range(2)
+    ]
+    scheduler.start()
+    try:
+        await asyncio.wait_for(adapter.delivered.wait(), timeout=5)
+    finally:
+        await scheduler.stop()
+    assert sorted(adapter.sent) == [("channel-0", expected), ("channel-1", expected)]
+    assert runtime.calls == ["calculate", "calculate"]
+    for task in tasks:
+        assert task.status == "completed"
+        assert task.last_result is result
+        assert task.last_result == original
+    assert result["results"]["node"]["results"] is contributors

--- a/ui/src/__tests__/IntentSurface.bf812.test.tsx
+++ b/ui/src/__tests__/IntentSurface.bf812.test.tsx
@@ -7,12 +7,238 @@
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { render, screen, cleanup, act, fireEvent, waitFor } from '@testing-library/react';
+import { execFile } from 'node:child_process';
+import { existsSync, statSync } from 'node:fs';
+import { mkdir, mkdtemp, realpath, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import { IntentSurface } from '../components/IntentSurface';
 import { useStore } from '../store/useStore';
+import { speakResponse } from '../audio/voice';
+
+vi.mock('../audio/voice', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../audio/voice')>();
+  return { ...actual, speakResponse: vi.fn() };
+});
+
+interface CalculatorRequest {
+  message: string;
+  history: Array<{ role: string; text: string }>;
+  attachment_ids: string[];
+}
+
+interface CalculatorPair {
+  request: CalculatorRequest;
+  envelope: {
+    response: string;
+    dag: { source_text: string; reflect: boolean };
+    results: Record<string, { result_count: number; results: Array<{ agent_id: string }> }>;
+  };
+}
+
+const repeatedCommand = 'calculate 17 multiplied by 23 and return only the answer';
+const calculatorRequests: CalculatorRequest[] = [
+  repeatedCommand,
+  repeatedCommand,
+  'calculate 11 multiplied by 13 and return only the answer',
+  'calculate 17 multiplied by 23 twice as separate tasks',
+  repeatedCommand,
+].map((message, index) => ({
+  message,
+  history: index === 1
+    ? [{ role: 'user', text: repeatedCommand }, { role: 'system', text: '391' }]
+    : [],
+  attachment_ids: [],
+}));
+
+async function resolveCalculatorPython(
+  root: string,
+  overrides: { PROBOS_TEST_PYTHON?: string; PROBOS_PYTHON?: string } = process.env,
+): Promise<string> {
+  const isFile = (candidate: string): boolean => existsSync(candidate) && statSync(candidate).isFile();
+  for (const name of ['PROBOS_TEST_PYTHON', 'PROBOS_PYTHON'] as const) {
+    if (overrides[name] === undefined) continue;
+    const candidate = resolve(root, overrides[name]);
+    if (!overrides[name] || !isFile(candidate)) {
+      throw new Error(`${name} must name an existing Python executable: ${candidate}`);
+    }
+    return realpath(candidate);
+  }
+  const candidates = ['.venv/Scripts/python.exe', '.venv/bin/python'].map((relative) => join(root, relative));
+  const local = candidates.find(isFile);
+  if (local) return realpath(local);
+  let commonDirectory: string;
+  try {
+    const output = await new Promise<string>((accept, reject) => {
+      execFile('git', ['-C', root, 'rev-parse', '--git-common-dir'], {
+        shell: false, timeout: 5_000, maxBuffer: 65_536, encoding: 'utf8',
+      }, (error, stdout) => error ? reject(error) : accept(stdout.trim()));
+    });
+    if (!output) throw new Error('Git returned an empty common directory');
+    commonDirectory = await realpath(resolve(root, output));
+  } catch (error) {
+    throw Object.assign(new Error(
+      'Cannot resolve the backend test environment. Set PROBOS_TEST_PYTHON or PROBOS_PYTHON, '
+      + 'or run uv sync --group dev --extra discovery --extra browser in the repository.',
+    ), { cause: error });
+  }
+  candidates.push(...['.venv/Scripts/python.exe', '.venv/bin/python']
+    .map((relative) => join(dirname(commonDirectory), relative)));
+  const common = candidates.find(isFile);
+  if (common) return realpath(common);
+  throw new Error(
+    'No backend test interpreter found. Set PROBOS_TEST_PYTHON or PROBOS_PYTHON, '
+    + 'or run uv sync --group dev --extra discovery --extra browser. Checked: '
+    + candidates.join(', '),
+  );
+}
+
+async function cleanupCalculatorDirectory(
+  temporary: string, originalError: unknown, remove: typeof rm = rm,
+): Promise<void> {
+  try {
+    await remove(temporary, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+  } catch (cleanupError) {
+    if (originalError !== undefined) {
+      throw Object.assign(new Error('Calculator execution and cleanup failed'), {
+        errors: [originalError, cleanupError], cause: originalError,
+      });
+    }
+    throw cleanupError;
+  }
+  if (originalError !== undefined) throw originalError;
+}
+
+function parseCalculatorBatch(stdout: string, context: string): { pairs: CalculatorPair[] } {
+  try {
+    return JSON.parse(stdout) as { pairs: CalculatorPair[] };
+  } catch (error) {
+    throw Object.assign(new Error(`Calculator API fixture returned invalid JSON. ${context}`), { cause: error });
+  }
+}
+
+async function loadCalculatorPairs(): Promise<CalculatorPair[]> {
+  const started = Date.now();
+  const root = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+  const python = await resolveCalculatorPython(root);
+  const input = JSON.stringify(calculatorRequests);
+  if (Buffer.byteLength(input) > 65_536) throw new Error('Calculator request batch is too large');
+  const temporary = await mkdtemp(join(tmpdir(), 'probos-calculator-test-'));
+  let pairs: CalculatorPair[] | undefined;
+  let setupError: unknown;
+  try {
+    const remaining = 50_000 - (Date.now() - started);
+    if (remaining <= 0) throw new Error('Calculator setup exhausted its child-work budget');
+    const script = [
+      'import json, os, runpy, sys',
+      "with os.fdopen(os.dup(1), 'w', encoding='utf-8') as protocol:",
+      '    os.dup2(2, 1)',
+      "    os.write(1, b'issue1378-native-stdout-check\\n')",
+      "    module = runpy.run_path('tests/test_hxi_chat_integration.py', run_name='probos_test_bridge')",
+      "    batch = module['_calculator_bridge']()",
+      '    json.dump(batch, protocol)',
+      '    protocol.flush()',
+    ].join('\n');
+    const output = await new Promise<{ stdout: string; context: string; stderr: string }>((accept, reject) => {
+      let inputFailure: Error | undefined;
+      const child = execFile(python, ['-c', script], {
+        cwd: root,
+        shell: false,
+        timeout: remaining,
+        killSignal: 'SIGKILL',
+        maxBuffer: 1_048_576,
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          PYTHONPATH: join(root, 'src'),
+          PROBOS_DATA_DIR: temporary,
+          PROBOS_EMBEDDINGS: 'local',
+          PROBOS_NATS_ENABLED: 'false',
+          HF_HUB_OFFLINE: '1',
+        },
+      }, (error, output, stderr) => {
+        const context = `${python}, ${Date.now() - started}ms, exit=${error?.code ?? 0}, `
+          + `signal=${error?.signal ?? 'none'}\n${stderr}`;
+        if (error || inputFailure) {
+          reject(new Error(`Calculator API fixture failed: ${inputFailure ?? error}\n${context}`));
+        } else {
+          accept({ stdout: output, context, stderr });
+        }
+      });
+      child.stdin?.once('error', (error: Error) => {
+        inputFailure = error;
+        child.kill('SIGKILL');
+      });
+      child.stdin?.end(input);
+    });
+    expect(output.stderr).toContain('issue1378-native-stdout-check');
+    expect(output.stdout).not.toContain('issue1378-native-stdout-check');
+    const batch = parseCalculatorBatch(output.stdout, output.context);
+    expect(Object.keys(batch)).toEqual(['pairs']);
+    expect(batch.pairs).toHaveLength(5);
+    expect(batch.pairs.map((pair) => pair.request)).toEqual(calculatorRequests);
+    expect(batch.pairs.map((pair) => pair.envelope.response)).toEqual([
+      '391', '391', '143', '391\n391', '391',
+    ]);
+    for (const [index, pair] of batch.pairs.entries()) {
+      expect(pair.envelope.dag).toEqual({ source_text: pair.request.message, reflect: false });
+      const nodes = Object.values(pair.envelope.results);
+      expect(nodes).toHaveLength(index === 3 ? 2 : 1);
+      for (const node of nodes) {
+        expect(node.results.length).toBeGreaterThanOrEqual(2);
+        expect(node.result_count).toBe(node.results.length);
+        expect(new Set(node.results.map((result) => result.agent_id)).size).toBe(node.result_count);
+      }
+    }
+    pairs = batch.pairs;
+  } catch (error) {
+    setupError = error;
+  }
+  await cleanupCalculatorDirectory(temporary, setupError);
+  if (!pairs) throw new Error('Calculator setup completed without its required batch');
+  expect(existsSync(temporary)).toBe(false);
+  const elapsedMs = Date.now() - started;
+  if (elapsedMs >= 60_000) throw new Error(`Calculator fixture setup exceeded its budget: ${elapsedMs}ms`);
+  console.info('Issue 1378 API fixture setup', { elapsedMs, childExit: 0, pairs: pairs.length, cleanupVerified: true });
+  return pairs;
+}
+
+const calculatorSetup = await loadCalculatorPairs().then(
+  (pairs) => ({ pairs, error: undefined }),
+  (error: unknown) => ({ pairs: [] as CalculatorPair[], error }),
+);
+const calculatorPairs = calculatorSetup.pairs;
+
+function matchCalculatorPair(body: unknown, pair: CalculatorPair): CalculatorPair['envelope'] {
+  expect(body).toEqual(pair.request);
+  expect(pair.envelope.dag.source_text).toBe(pair.request.message);
+  return pair.envelope;
+}
+
+function installCalculatorFetch(pairs: CalculatorPair[]): () => void {
+  const original = structuredClone(pairs);
+  let consumed = 0;
+  vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    if (String(input) !== '/api/chat') {
+      return { ok: true, status: 200, json: async () => ({}) } as Response;
+    }
+    expect(init?.method).toBe('POST');
+    expect(consumed).toBeLessThan(pairs.length);
+    const envelope = matchCalculatorPair(JSON.parse(String(init?.body)), pairs[consumed]);
+    consumed += 1;
+    return { ok: true, status: 200, json: async () => envelope } as Response;
+  }));
+  return () => {
+    expect(consumed).toBe(pairs.length);
+    expect(pairs).toEqual(original);
+  };
+}
 
 let chatBody: unknown = { response: 'ok' };
 let chatStatus = 200;
+let previousVoiceEnabled = false;
 
 function installFetch(): void {
   vi.stubGlobal('fetch', vi.fn((input: RequestInfo | URL) => {
@@ -57,14 +283,16 @@ function chatTexts(): Array<{ role: string; text: string }> {
 }
 
 beforeEach(() => {
+  previousVoiceEnabled = useStore.getState().voiceEnabled;
   chatBody = { response: 'ok' };
   chatStatus = 200;
   installFetch();
-  useStore.setState({ chatHistory: [], activeDag: [], pendingRequests: 0, agents: new Map() });
+  useStore.setState({ chatHistory: [], activeDag: [], pendingRequests: 0, agents: new Map(), voiceEnabled: false });
 });
 
 afterEach(() => {
   cleanup();
+  useStore.setState({ voiceEnabled: previousVoiceEnabled, chatHistory: [], pendingRequests: 0 });
   vi.unstubAllGlobals();
   vi.clearAllMocks();
 });
@@ -96,5 +324,112 @@ describe('BF-812 IntentSurface renders a policy refusal as policy state', () => 
     });
     expect(chatTexts().some((m) => m.text.toLowerCase().includes('policy refused')))
       .toBe(false);
+  });
+});
+
+describe('Issue 1378 real API envelopes reach HXI history and narration', () => {
+  beforeEach(() => {
+    if (calculatorSetup.error) throw calculatorSetup.error;
+    expect(calculatorPairs).toHaveLength(5);
+  });
+
+  it('keeps repeated requests as separate answers and utterances', async () => {
+    const verify = installCalculatorFetch(calculatorPairs.slice(0, 2));
+    useStore.setState({ voiceEnabled: true });
+    render(<IntentSurface />);
+    for (let occurrence = 1; occurrence <= 2; occurrence += 1) {
+      await ask(repeatedCommand);
+      await waitFor(() => {
+        expect(chatTexts().filter((message) => message.role === 'system')).toHaveLength(occurrence);
+        expect(vi.mocked(speakResponse)).toHaveBeenCalledTimes(occurrence);
+      });
+      expect(screen.getAllByText('391', { exact: true })).toHaveLength(occurrence);
+      expect(vi.mocked(speakResponse)).toHaveBeenNthCalledWith(
+        occurrence, '391', undefined, undefined, undefined, 'narration',
+      );
+    }
+    expect(chatTexts().filter((message) => message.role === 'system').map((message) => message.text))
+      .toEqual(['391', '391']);
+    verify();
+  });
+
+  it.each([2, 3])('preserves the real result and node boundaries for scenario %s', async (index) => {
+    const pair = calculatorPairs[index];
+    const verify = installCalculatorFetch([pair]);
+    useStore.setState({ voiceEnabled: true });
+    render(<IntentSurface />);
+    await ask(pair.request.message);
+    await waitFor(() => expect(chatTexts().filter((message) => message.role === 'system'))
+      .toEqual([{ role: 'system', text: pair.envelope.response }]));
+    expect(vi.mocked(speakResponse)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(speakResponse).mock.calls[0][2]).toBeUndefined();
+    expect(vi.mocked(speakResponse).mock.calls[0][4]).toBe('narration');
+    expect(vi.mocked(speakResponse).mock.calls[0][0].replace(/\s+/g, ' ').trim())
+      .toBe(pair.envelope.response.replace(/\s+/g, ' ').trim());
+    verify();
+  });
+
+  it('keeps the real answer visible while voice is disabled', async () => {
+    const pair = calculatorPairs[4];
+    const verify = installCalculatorFetch([pair]);
+    render(<IntentSurface />);
+    await ask(pair.request.message);
+    await waitFor(() => expect(chatTexts().filter((message) => message.role === 'system'))
+      .toEqual([{ role: 'system', text: '391' }]));
+    expect(screen.getByText('391', { exact: true })).toBeTruthy();
+    expect(vi.mocked(speakResponse)).not.toHaveBeenCalled();
+    verify();
+  });
+
+  it('rejects a mismatched request rather than serving a plausible cached answer', () => {
+    const pair = calculatorPairs[0];
+    expect(() => matchCalculatorPair({ ...pair.request, message: calculatorPairs[2].request.message }, pair))
+      .toThrow();
+    expect(() => matchCalculatorPair({ ...pair.request, attachment_ids: ['unrelated'] }, pair)).toThrow();
+  });
+});
+
+describe('Issue 1378 fixture failure diagnostics', () => {
+  it('resolves strict explicit overrides and local environments without scanning unrelated paths', async () => {
+    const temporary = await mkdtemp(join(tmpdir(), 'probos-calculator-test-'));
+    try {
+      const executable = join(temporary, '.venv', 'Scripts', 'python.exe');
+      await mkdir(dirname(executable), { recursive: true });
+      await writeFile(executable, 'resolver-only fixture');
+      expect(await resolveCalculatorPython(temporary, {})).toBe(await realpath(executable));
+      expect(await resolveCalculatorPython(temporary, { PROBOS_TEST_PYTHON: '.venv/Scripts/python.exe' }))
+        .toBe(await realpath(executable));
+      expect(await resolveCalculatorPython(temporary, { PROBOS_PYTHON: executable }))
+        .toBe(await realpath(executable));
+      await expect(resolveCalculatorPython(temporary, {
+        PROBOS_TEST_PYTHON: 'missing', PROBOS_PYTHON: executable,
+      })).rejects.toThrow('PROBOS_TEST_PYTHON');
+      await expect(resolveCalculatorPython(temporary, { PROBOS_PYTHON: 'missing' }))
+        .rejects.toThrow('PROBOS_PYTHON');
+      await rm(join(temporary, '.venv'), { recursive: true });
+      await expect(resolveCalculatorPython(temporary, {})).rejects.toThrow('uv sync --group dev');
+    } finally {
+      await rm(temporary, { recursive: true, force: true });
+    }
+  });
+
+  it('retains both the original child failure and a cleanup failure', async () => {
+    const original = new Error('child traceback');
+    const cleanupError = new Error('cleanup EBUSY');
+    const remove = vi.fn<typeof rm>().mockRejectedValue(cleanupError);
+    await expect(cleanupCalculatorDirectory('owned-fixture', original, remove))
+      .rejects.toMatchObject({ errors: [original, cleanupError] });
+    expect(remove).toHaveBeenCalledWith('owned-fixture', {
+      recursive: true, force: true, maxRetries: 10, retryDelay: 100,
+    });
+    await expect(cleanupCalculatorDirectory('owned-fixture', undefined, remove)).rejects.toBe(cleanupError);
+    remove.mockResolvedValue(undefined);
+    await expect(cleanupCalculatorDirectory('owned-fixture', original, remove)).rejects.toBe(original);
+  });
+
+  it('retains executable and stderr evidence when JSON protocol parsing fails', () => {
+    expect(() => parseCalculatorBatch('native-output\n{}', 'python-fixture exit=0 signal=none stderr-marker'))
+      .toThrow('python-fixture exit=0 signal=none stderr-marker');
+    expect(() => parseCalculatorBatch('{} trailing', 'bounded-context')).toThrow('bounded-context');
   });
 });


### PR DESCRIPTION
## Summary
- Suppress only demonstrably equivalent successful contributions from distinct agents within one node, preserving all raw evidence and independent work.
- Cover real calculators through the API and request-matched mounted HXI history/narration, plus channel history and scheduled delivery.
- Bootstrap Python in UI CI for the actual-runtime fixture; existing timeouts and gates remain unchanged.

## Validation
- Reviewed commit: a26e90034327adb3cf41fda455092281347a673d; tree: 14d7515a89c1cb54a2b24ca2fc84b3269311fa87.
- Canonical full repository gate: 30,200 passed, 30 skipped, exit 0; original interrupted attempt retained as nonpassing evidence.
- Focused backend: 184 passed; formatter: 138 passed; focused UI: 10 passed; full UI: 2,845 passed, 1 skipped; production build and preflight passed.
- Independent precommit and formal committed reviews: clean. Host-verified Claude Opus 5 reviewer versus GPT-6 Astra author; exact handoff chain verified.
- Canonical receipt SHA256: f847185e48136cbe20bafb4f3ed529abee9a00ea99dd1ec3032bbd2e343eb052.
- Linux CI execution remains to be verified before merge. Test bridge uses real producer-generated API envelopes, not live per-mounted-request HTTP.

Closes #1378